### PR TITLE
Refactor grid

### DIFF
--- a/source/controllers/createMenuController.d
+++ b/source/controllers/createMenuController.d
@@ -10,7 +10,7 @@ import gtk.ToggleButton;
 
 import controllers.sudokuController;
 import controllers.sudokuWorld;
-import core.sudoku.sudoku : SudokuType;
+import core.sudoku.grid : SudokuType;
 import extra;
 import ui.menus.createMenu;
 import ui.sudoku.gridUI;
@@ -22,7 +22,7 @@ public class CreateMenuController
 		trace("Initializing CreateMenuController");
 		this.createMenu = createMenu;
 		this.sudokuWorld = sudokuWorld;
-		auto sc = sudokuWorld.addSudokuController(GameState.Create, SudokuType.Sudoku_4X4);
+		auto sc = sudokuWorld.addSudokuController(GameState.Create, SudokuType.Sudoku4x4);
 		createMenu.addGrid(GameState.Create, sc.gridUI);
 		createMenu.showGrid(sc.gridUI);
 		callbacks();

--- a/source/controllers/sudokuController.d
+++ b/source/controllers/sudokuController.d
@@ -32,7 +32,7 @@ public class SudokuController
 		this.sudokuWorld = sudokuWorld;
 		_gameState = gameState;
 
-		gridUI.buildCells(grid.toDigit(), grid.height, grid.width);
+		gridUI.buildCells(grid.toDigit(), grid.rows, grid.columns);
 		callbacks();
 	}
 

--- a/source/controllers/sudokuWorld.d
+++ b/source/controllers/sudokuWorld.d
@@ -112,8 +112,8 @@ public void setCreateMenuCellInfoText(in int column, in int row, in int digit)
 
 	public auto addSudokuController(GameState state, SudokuType type)
 	{
-		Grid grid = new Grid(Sudoku.dimension(type).expand);
-		grid.initialize(new int[][](grid.height, grid.width));
+		Grid grid = new Grid(type);
+		grid.initialize(new int[][](grid.rows, grid.columns));
 		GridUI gridUI = new GridUI(type);
 		SudokuController sd = new SudokuController(grid, gridUI, state, this);
 		return sudokuControllers[state] = sd;
@@ -123,7 +123,7 @@ public void setCreateMenuCellInfoText(in int column, in int row, in int digit)
 	public auto addSudokuController(GameState state, SudokuController sudokuController)
 	{
 		SudokuType type = sudokuController.gridUI.type;
-		Grid grid = new Grid(Sudoku.dimension(type).expand);
+		Grid grid = new Grid(type);
 		int[][] digits = sudokuController.grid.toDigit();
 		grid.initialize(digits);
 		GridUI gridUI = new GridUI(type);

--- a/source/core/constraint/constraint.d
+++ b/source/core/constraint/constraint.d
@@ -21,6 +21,7 @@ public abstract class Constraint : IConstraint
 	public abstract void connect(Cell cell);
 	public abstract bool isValid(in int digit);
 
+	@safe pure
 	public ConstraintType constraintType() const @property
 	{
 		return _constraintType;
@@ -30,17 +31,13 @@ public abstract class Constraint : IConstraint
 	{
 		if (!canFind(cells, cell))
 		{
-			_cells ~= cell;
+			cells ~= cell;
 			return true;
 		}
 		return false;
 	}
 
-	public auto cells() @property
-	{
-		return _cells;
-	}
 
-	protected Cell[] _cells;
+	public Cell[] cells;
 	protected ConstraintType _constraintType;
 }

--- a/source/core/constraint/unique.d
+++ b/source/core/constraint/unique.d
@@ -13,10 +13,10 @@ import core.sudoku.cell;
  */
 public class UniqueConstraint : Constraint
 {
-	private this(Cell[] cells ...)
+	private this(Cell[] cells...)
 	{
 		super (ConstraintType.Unique);
-		this._cells ~= cells;
+		this.cells ~= cells;
 	}
 
 
@@ -52,6 +52,7 @@ public class UniqueConstraint : Constraint
 	}
 
 
+	@safe pure
 	public static ConstraintType getStaticConstraintType()
 	{
 		return ConstraintType.Unique;

--- a/source/core/rule/rule.d
+++ b/source/core/rule/rule.d
@@ -17,7 +17,7 @@ version(unittest)
 	import aurorafw.unit;
 	import core.constraint;
 	import core.sudoku.cell;
-	import core.sudoku.sudoku;
+	import core.sudoku.grid;
 	import std.algorithm : canFind;
 }
 
@@ -33,9 +33,8 @@ public void addRule(Grid grid, RuleType rule)
 @("core:rule:rule: addRule")
 unittest
 {
-	const auto dim = Sudoku.dimension(SudokuType.Sudoku_4X4);
-	Grid grid = new Grid(dim.expand);
-	grid.initialize(new int[][](dim.rows, dim.columns));
+	Grid grid = new Grid(SudokuType.Sudoku4x4);
+	grid.initialize();
 	grid.addRule(RuleType.Classic);
 
 	assertTrue(grid.toArray().each!(cell => cell.get!UniqueConstraint.cells.length == 8));
@@ -52,17 +51,16 @@ unittest
 public void addRuleClassic(Grid grid)
 {
 		// rows, columns, boxes
-		iota(grid.height).each!(i => UniqueConstraint.createInterconnected(grid.row(i)));
-		iota(grid.width).each!(i => UniqueConstraint.createInterconnected(grid.column(i)));
-		iota(grid.height).each!(i => UniqueConstraint.createInterconnected(grid.box(i).toArray()));
+		iota(grid.rows).each!(i => UniqueConstraint.createInterconnected(grid.row(i)));
+		iota(grid.columns).each!(i => UniqueConstraint.createInterconnected(grid.column(i)));
+		iota(grid.rows).each!(i => UniqueConstraint.createInterconnected(grid.box(i).toArray()));
 }
 
 @("core:rule:rule: addRuleClassic")
 unittest
 {
-	const auto dim = Sudoku.dimension(SudokuType.Sudoku_4X4);
-	Grid grid = new Grid(dim.expand);
-	grid.initialize(new int[][](dim.rows,dim.columns));
+	Grid grid = new Grid(SudokuType.Sudoku4x4);
+	grid.initialize();
 	addRuleClassic(grid);
 
 	auto cells = grid[0,0].get!UniqueConstraint.cells;
@@ -91,9 +89,8 @@ public void addRuleX(Grid grid)
 @("core:rule:rule: addRuleX")
 unittest
 {
-	const auto dim = Sudoku.dimension(SudokuType.Sudoku_4X4);
-	Grid grid = new Grid(dim.expand);
-	grid.initialize(new int[][](dim.rows,dim.columns));
+	Grid grid = new Grid(SudokuType.Sudoku4x4);
+	grid.initialize();
 	addRuleX(grid);
 
 	auto cells = grid[0,0].get!UniqueConstraint.cells;

--- a/source/core/sudoku/box.d
+++ b/source/core/sudoku/box.d
@@ -1,15 +1,18 @@
 module core.sudoku.box;
 
+import std.array: join;
+
 import core.sudoku.cell;
+import core.sudoku.grid;
 
 public class Box
 {
-	public this(int height, int width)
+	public this(in int rows, in int columns)
 	{
-		this.width = width;
-		this.height = height;
+		this.columns = columns;
+		this.rows = rows;
 
-		cells = new Cell[][](height, width);
+		cells = new Cell[][](rows, columns);
 	}
 
 
@@ -28,12 +31,24 @@ public class Box
 	 */
 	public Cell[] toArray()
 	{
-		import std.array: join;
-		return cells.join;
+		return Grid.toArray(cells);
 	}
 
-	public int width;
-	public int height;
+
+	/** Get Cell digits
+	 *
+	 * Params:
+	 *     cells = matrix of Cells to analyse
+	 *
+	 * Returns:
+	 *     `int[][]` with the current digits stored in each Cell of cells
+	 */
+	public int[][] toDigit()
+	{
+		return Grid.toDigit(cells);
+	}
 
 	public Cell[][] cells;
+	public const int columns;
+	public const int rows;
 }

--- a/source/core/sudoku/cell.d
+++ b/source/core/sudoku/cell.d
@@ -4,10 +4,10 @@ import core.constraint.constraint;
 
 public class Cell
 {
-	public this(int digit)
+	public this(in int digit)
 	{
 		this.digit = digit;
-		isBlocked = !digit ? false : true;
+		isBlocked = digit != 0;
 	}
 
 
@@ -40,6 +40,7 @@ public class Cell
 	}
 
 
+	@safe
 	public C get(C : Constraint)()
 	{
 		foreach (Constraint c; constraints)
@@ -78,7 +79,8 @@ public class Cell
 		return true;
 	}
 
-	public bool isBlocked;
+
+	public const bool isBlocked;
 	public int digit;
 
 	public Constraint[] constraints;

--- a/source/core/sudoku/sudoku.d
+++ b/source/core/sudoku/sudoku.d
@@ -9,44 +9,24 @@ import core.sudoku.cell;
 import core.sudoku.grid;
 
 
-public enum SudokuType
-{
-	Sudoku_4X4,
-	Sudoku_6X6,
-	Sudoku_9X9,
-}
-
 public class Sudoku
 {
-	public this(SudokuType type)
+	public this(Grid grid)
 	{
-		auto dim = dimension(type);
-		this.type = type;
-		this.rows = dim.rows;
-		this.columns = dim.columns;
-		this.boxRows = dim.boxRows;
-		this.boxColumns = dim.boxColumns;
-
-		grid = new Grid(rows, columns, boxRows, boxColumns);
-	}
-
-
-	public void initialize(int[][] digits)
-	{
-		grid.initialize(digits);
+		this.grid = grid;
 	}
 
 
 	public auto solve()
 	{
 		backtrackAlgorithm(0,0);
-		return solution = grid.toDigit();
+		return grid.toDigit();
 	}
 
 
-	public int backtrackAlgorithm(in int row, in int column)
+	private int backtrackAlgorithm(in int row, in int column)
 	{
-		auto coords = grid.nextCell(row, column);
+		auto coords = nextCell(row, column);
 
 		// if a cell is blocked (has a given number) we move foward
 		if (grid.cells[row][column].isBlocked)
@@ -57,7 +37,7 @@ public class Sudoku
 
 		// let's try every number from 1 to our max digit
 		// max digit is the row/column length
-		for (int i = 1; i <= rows; i++)
+		for (int i = 1; i <= grid.rows; i++)
 		{
 			if (grid.cells[row][column].isValid(i))
 			{
@@ -76,27 +56,33 @@ public class Sudoku
 	}
 
 
-	/** Standard Sudoku dimensions
+	/** Position of the next cell
+	 *
+	 * This is used internaly by the backtrackAlgorithm
 	 *
 	 * Params:
-	 *     type = SudokuType to process
+	 *     row = current row int the Grid
+	 *     column = current column int the Grid
 	 *
-	 * Returns: `tuple`***("rows","columns","boxRows","boxColumns")*** with the
-	 *     dimensions of SudokuType
+	 * Returns:
+	 *     `tuple`***("row","column")*** with the position of the next Cell \
+	 *     `tuple`***("row","column")(-1,-1)*** if params correspond to the last Cell
 	 */
-	public static auto dimension(SudokuType type)
+	private auto nextCell(int row, int column)
 	{
-		final switch (type)
-		{
-			case SudokuType.Sudoku_4X4:
-				return tuple!("rows","columns","boxRows","boxColumns")(4,4,2,2);
+		import std.typecons : tuple;
 
-			case SudokuType.Sudoku_6X6:
-				return tuple!("rows","columns","boxRows","boxColumns")(6,6,2,3);
+		// last cell of grid
+		if (row == grid.rows - 1 && column == grid.columns - 1)
+			return tuple!("row","column")(-1, -1);
 
-			case SudokuType.Sudoku_9X9:
-				return tuple!("rows","columns","boxRows","boxColumns")(9,9,3,3);
-		}
+		// last cell of column
+		else if (column == grid.columns - 1)
+			return tuple!("row","column")(row + 1, 0);
+
+		// cell in the middle
+		else
+			return tuple!("row","column")(row, column + 1);
 	}
 
 
@@ -145,14 +131,7 @@ public class Sudoku
 	}
 
 
-	public int rows;
-	public int columns;
-	public int boxRows;
-	public int boxColumns;
-
-	public SudokuType type;
-	public Grid grid;
-	public int[][] solution;
+	private Grid grid;
 }
 
 
@@ -210,10 +189,11 @@ version(unittest)
 @("core:sudoku:sudoku: classic solve 4x4")
 unittest
 {
-	Sudoku sudoku = new Sudoku(SudokuType.Sudoku_4X4);
+	Grid grid = new Grid(SudokuType.Sudoku4x4);
+	grid.initialize(classic4x4);
+	addRuleClassic(grid);
 
-	sudoku.initialize(classic4x4);
-	addRuleClassic(sudoku.grid);
+	Sudoku sudoku = new Sudoku(grid);
 
 	assertTrue(sudoku.solve() == classicSolve4x4);
 }
@@ -221,10 +201,11 @@ unittest
 @("core:sudoku:sudoku: classic solve 6x6")
 unittest
 {
-	Sudoku sudoku = new Sudoku(SudokuType.Sudoku_6X6);
+	Grid grid = new Grid(SudokuType.Sudoku6x6);
+	grid.initialize(classic6x6);
+	addRuleClassic(grid);
 
-	sudoku.initialize(classic6x6);
-	addRuleClassic(sudoku.grid);
+	Sudoku sudoku = new Sudoku(grid);
 
 	assertTrue(sudoku.solve() == classicSolve6x6);
 }
@@ -232,10 +213,11 @@ unittest
 @("core:sudoku:sudoku: classic solve 9x9")
 unittest
 {
-	Sudoku sudoku = new Sudoku(SudokuType.Sudoku_9X9);
+	Grid grid = new Grid(SudokuType.Sudoku9x9);
+	grid.initialize(classic9x9);
+	addRuleClassic(grid);
 
-	sudoku.initialize(classic9x9);
-	addRuleClassic(sudoku.grid);
+	Sudoku sudoku = new Sudoku(grid);
 
 	assertTrue(sudoku.solve() == classicSolve9x9);
 }
@@ -273,10 +255,12 @@ version(unittest)
 @("core:sudoku:sudoku: x solve 4x4")
 unittest
 {
-	Sudoku sudoku = new Sudoku(SudokuType.Sudoku_4X4);
+	Grid grid = new Grid(SudokuType.Sudoku4x4);
+	grid.initialize(x4x4);
+	addRuleClassic(grid);
 
-	sudoku.initialize(x4x4);
-	addRuleClassic(sudoku.grid);
+	Sudoku sudoku = new Sudoku(grid);
+
 	addRuleX(sudoku.grid);
 
 	assertTrue(sudoku.solve() == xSolve4x4);
@@ -285,11 +269,12 @@ unittest
 @("core:sudoku:sudoku: x solve 6x6")
 unittest
 {
-	Sudoku sudoku = new Sudoku(SudokuType.Sudoku_6X6);
+	Grid grid = new Grid(SudokuType.Sudoku6x6);
+	grid.initialize(x6x6);
+	addRuleClassic(grid);
+	addRuleX(grid);
 
-	sudoku.initialize(x6x6);
-	addRuleClassic(sudoku.grid);
-	addRuleX(sudoku.grid);
+	Sudoku sudoku = new Sudoku(grid);
 
 	assertTrue(sudoku.solve() == xSolve6x6);
 }

--- a/source/ui/menus/createMenu.d
+++ b/source/ui/menus/createMenu.d
@@ -25,7 +25,7 @@ import gtk.Window;
 
 import controllers.sudokuController : GameState;
 import core.rule.rule : RuleType;
-import core.sudoku.sudoku : SudokuType;
+import core.sudoku.grid : SudokuType;
 import extra : toEnumString;
 import ui.sudoku.gridUI;
 

--- a/source/ui/sudoku/boxUI.d
+++ b/source/ui/sudoku/boxUI.d
@@ -4,7 +4,7 @@ import std.typecons : tuple;
 
 import gtk.Grid;
 
-import core.sudoku.sudoku : SudokuType;
+import core.sudoku.grid : SudokuType;
 
 public class BoxUI : Grid
 {
@@ -22,9 +22,9 @@ public class BoxUI : Grid
 	{
 		final switch (type)
 		{
-			case SudokuType.Sudoku_4X4: return tuple(300,300);
-			case SudokuType.Sudoku_6X6: return tuple(300,200);
-			case SudokuType.Sudoku_9X9: return tuple(195,195);
+			case SudokuType.Sudoku4x4: return tuple(300,300);
+			case SudokuType.Sudoku6x6: return tuple(300,200);
+			case SudokuType.Sudoku9x9: return tuple(195,195);
 		}
 	}
 }

--- a/source/ui/sudoku/cellUI.d
+++ b/source/ui/sudoku/cellUI.d
@@ -23,7 +23,7 @@ import gtk.Stack;
 import gtk.Widget;
 
 import core.sudoku.cell;
-import core.sudoku.sudoku;
+import core.sudoku.grid : SudokuType;
 import ui.sudoku.gridUI;
 import ui.sudoku.sudokuHelper;
 
@@ -40,7 +40,7 @@ public enum Color : Tuple!(double, double, double)
 
 public class CellUI : DrawingArea
 {
-	public this(SudokuType type, int row, int column, int digit)
+	public this(SudokuType type, int row, int column, int digit, int maxDigit)
 	{
 		setHalign(GtkAlign.CENTER);
 		setValign(GtkAlign.CENTER);
@@ -61,7 +61,7 @@ public class CellUI : DrawingArea
 
 		this._row = row;
 		this._column = column;
-		this._maxDigit = Sudoku.dimension(type).rows;
+		this._maxDigit = maxDigit;
 		this._digit = digit;
 		this._isBlocked = _digit != 0;
 	}
@@ -71,9 +71,9 @@ public class CellUI : DrawingArea
 	{
 		final switch(type)
 		{
-			case SudokuType.Sudoku_4X4: return tuple(150,150);
-			case SudokuType.Sudoku_6X6: return tuple(100,100);
-			case SudokuType.Sudoku_9X9: return tuple(65,65);
+			case SudokuType.Sudoku4x4: return tuple(150,150);
+			case SudokuType.Sudoku6x6: return tuple(100,100);
+			case SudokuType.Sudoku9x9: return tuple(65,65);
 		}
 	}
 

--- a/source/ui/sudoku/gridUI.d
+++ b/source/ui/sudoku/gridUI.d
@@ -10,7 +10,7 @@ import gtk.Grid;
 import gtk.Label;
 import gtk.StyleContext;
 
-import core.sudoku.sudoku;
+import core.sudoku.grid : SudokuGrid = Grid, SudokuType;
 import core.rule.rule : RuleType;
 import ui.sudoku.boxUI;
 import ui.sudoku.cellUI;
@@ -35,7 +35,7 @@ public class GridUI : Grid
 		context.addClass("sudoku");
 
 		this._type = type;
-		auto dimensions = Sudoku.dimension(type);
+		const auto dimensions = SudokuGrid.dimensions(type);
 		setDimensions(dimensions.expand);
 		buildBoxes(dimensions.boxRows, dimensions.boxColumns);
 
@@ -80,7 +80,7 @@ public class GridUI : Grid
 		{
 			for (int x; x < columns; x++)
 			{
-				auto cell = new CellUI(type, y, x, digits[y][x]);
+				auto cell = new CellUI(type, y, x, digits[y][x], rows);
 				cells[y][x] = cell;
 				boxes[y / boxRows][x / boxCols].attach(cell, x % boxCols, y % boxRows, 1, 1);
 			}
@@ -92,10 +92,10 @@ public class GridUI : Grid
 	{
 		final switch(type)
 		{
-			case SudokuType.Sudoku_4X4:
-			case SudokuType.Sudoku_6X6:
+			case SudokuType.Sudoku4x4:
+			case SudokuType.Sudoku6x6:
 				return tuple(600,600);
-			case SudokuType.Sudoku_9X9:
+			case SudokuType.Sudoku9x9:
 				return tuple(585,585);
 		}
 	}


### PR DESCRIPTION
```md
What Changed:
Grid:
  - SudokuType was moved ot Grid: Sudoku should be an instance to invoke the solving algorithm and shouldn't have the knowledge of the types at all as they exist to define de Grid size only
  - Dimension names were was changed to match the UI classes convention
  - Dimension variables are now `const`
  - Added a toArray function to get all rows in one array
  - Added a getter which returns a tuple with all the dimensions
  - A new matrix with all of the digits starting at 0 can be initialized without passing the array as a parameter [1]
  - A Grid is now initialized by passing the SudokuType in the ctor instead of dimensions [2]

Box:
  - Dimension names were changed, same as Grid
  - `rows` and `columns` are now `const`
  - Added a function to get the Cells digit
  - Changed the logic of the functions to use the static version in Grid
```
[1]
```d
Grid grid = new Grid(SudokuType.Sudoku4x4);
grid.initialize(new int[][](grid.rows, grid.columns)); // old
grid.initialize(); // new
```
[2]
```d
Grid grid = new Grid(4,4,2,2) // old
Grid grid = new Grid(SudokuType.Sudoku4x4); //new
```