### PR TITLE
core:constraints:unique: Added remove functions and removed Cells connecting to themselves

### DIFF
--- a/source/core/constraint/unique.d
+++ b/source/core/constraint/unique.d
@@ -13,41 +13,179 @@ import core.sudoku.cell;
  */
 public class UniqueConstraint : Constraint
 {
-	private this(Cell[] cells...)
+	private this(Cell cell)
 	{
 		super (ConstraintType.Unique);
-		this.cells ~= cells;
+		this.cells ~= cell;
 	}
 
 
-	public static auto createSingle(Cell cell1, Cell cell2)
+	/** Connects two Cells
+	 *
+	 * Ensures `cell1` is connected to `cell2` and vice-versa \
+	 * This means when a digit is checked for it's availability in `cell1`
+	 *     the validation is dependent of the digit in `cell2` and vice-versa \
+	 * A Cell cannot connect to itself \
+	 * Null values are not processed
+	 *
+	 * Params:
+	 *     cell1 = cell to connect
+	 *     cell2 = cell to connect
+	 *
+	 * Examples:
+	 * --------------------
+	 * Cell cell1 = new Cell(0);
+	 * Cell cell2 = new Cell(0);
+	 * UniqueConstraint.createSingle(cell1,cell2);
+	 * assert(cell1.get!UniqueConstraint.cells.equal([cell2]));
+	 * assert(cell2.get!UniqueConstraint.cells.equal([cell1]));
+	 * --------------------
+	 */
+	public static void createSingle(Cell cell1, Cell cell2)
 	{
-		if (cell1 is null || cell2 is null) return;
-		UniqueConstraint uc1 = new UniqueConstraint(cell1, cell2);
+		if (cell1 is null || cell2 is null || cell1 == cell2)
+			return;
+
+		UniqueConstraint uc1 = new UniqueConstraint(cell2);
 		uc1.connect(cell1);
-		UniqueConstraint uc2 = new UniqueConstraint(cell1, cell2);
+		UniqueConstraint uc2 = new UniqueConstraint(cell1);
 		uc2.connect(cell2);
 	}
 
 
-	public static auto createMultiSingle(Cell cell, Cell[] cells...)
+	/** Connects a Cell to a group of Cells
+	 *
+	 * Ensures `cell` is connected to `cells` and that each Cell in `cells` is
+	 *     connected to `cell` \
+	 * A Cell cannot connect to itself \
+	 * Null values are not processed
+	 *
+	 * Params:
+	 *     cell = cell to connect
+	 *     cells = cells to be connected
+	 *
+	 * SeeAlso: void createSingle(**cell1**,**cell2**)
+	 */
+	public static void createMultiSingle(Cell cell, Cell[] cells...)
 	{
-		if (cell is null) return;
+		if (cell is null)
+			return;
+
 		foreach (Cell c; cells)
 		{
-			if (c is null) return;
+			if (c is null)
+				continue;
+
 			if (c != cell)
 				createSingle(cell, c);
 		}
 	}
 
 
-	public static auto createInterconnected(Cell[] cells...)
+	/** Connects group of Cells to each other
+	 *
+	 * Ensures all Cells in 'cells' are connected to each other \
+	 * A Cell cannot connect to itself \
+	 * Null values are not processed
+	 *
+	 * Params:
+	 *     cells = cells to connect to each other
+	 *
+	 * SeeAlso: void createSingle(**cell1**,**cell2**)
+	 */
+	public static void createInterconnected(Cell[] cells...)
 	{
+		import std.array : array;
+		import std.algorithm : filter;
+		if (canFind(cells, null))
+		{
+			cells = cells.filter!(cell => cell !is null).array;
+		}
+
 		foreach (Cell cell; cells)
 		{
-			if (cell is null) return;
 			createMultiSingle(cell, cells);
+		}
+	}
+
+
+	/** Removes a connection between two Cells
+	 *
+	 * A Cell cannot disconnect from itself \
+	 * Null values are not processed
+	 *
+	 * Params:
+	 *     cell1 = cell to disconnect
+	 *     cell2 = cell to disconnect
+	 */
+	public static void removeSingle(Cell cell1, Cell cell2)
+	{
+		if (cell1 is null || cell2 is null || cell1 == cell2)
+			return;
+
+		cell1.disconnect!UniqueConstraint(cell2);
+		cell2.disconnect!UniqueConstraint(cell1);
+	}
+
+
+	/** Removes a connection between a Cell and a group of Cells
+	 *
+	 * A Cell cannot disconnect from itself \
+	 * Null values are not processed
+	 *
+	 * Params:
+	 *     cell = cell to disconnect
+	 *     cells = cells to disconnect from
+	 */
+	public static void removeMultiSingle(Cell cell, Cell[] cells...)
+	{
+		foreach (c; cells)
+		{
+			if (c is null)
+				continue;
+
+			if (c != cell)
+				removeSingle(cell, c);
+		}
+	}
+
+
+	/** Removes a connection between Cells
+	 *
+	 * A Cell cannot disconnect from itself \
+	 * Null values are not processed
+	 *
+	 * Params:
+	 *     cells = cells to disconnect from each other
+	 */
+	public static void removeInterconnected(Cell[] cells...)
+	{
+		import std.array : array;
+		import std.algorithm : filter;
+		if (canFind(cells, null))
+		{
+			cells = cells.filter!(cell => cell !is null).array;
+		}
+
+		foreach (Cell cell; cells)
+		{
+			removeMultiSingle(cell, cells);
+		}
+	}
+
+
+	/** Removes a UniqueConstraint from a Cell
+	 *
+	 * Ensures all Cells connected to `cell` are disconnected from it aswell
+	 *
+	 * Params:
+	 *     cell = cell to remove UniqueConstraint
+	 */
+	public static void takeOut(Cell cell)
+	{
+		foreach (c; cell.get!UniqueConstraint.cells)
+		{
+			removeSingle(c, cell);
 		}
 	}
 
@@ -90,7 +228,11 @@ public class UniqueConstraint : Constraint
 }
 
 
-version(unittest) { import aurorafw.unit; }
+version(unittest)
+{
+	import aurorafw.unit;
+	import std.algorithm : equal;
+}
 
 @("core:constraint:unique: ctor")
 unittest
@@ -100,8 +242,8 @@ unittest
 
 	UniqueConstraint constraint = cells[0].get!UniqueConstraint;
 	assertTrue(constraint !is null);
-	assertTrue(constraint.isValid(2));
-	assertFalse(constraint.isValid(4));
+	assertTrue(constraint.isValid(4));
+	assertFalse(constraint.isValid(0));
 }
 
 
@@ -124,28 +266,29 @@ unittest
 	assertTrue(uc0 != uc1 && uc1 != uc2);
 
 
-	assertTrue(uc0.cells == uc1.cells && uc1.cells && uc2.cells);
-	assertTrue(uc0.cells == cells~cell);
+	assertFalse(uc0.cells.equal(uc1.cells));
+	assertTrue(uc0.cells.equal(cells[1..$] ~ cell));
 }
 
 
 @("core:constraint:unique: createSingle")
 unittest
 {
+	import std.algorithm : filter;
 	Cell[] cells = [new Cell(2), new Cell(3), new Cell(5)];
 	UniqueConstraint.createSingle(cells[0], cells[1]);
 
 	UniqueConstraint uc0 = cells[0].get!UniqueConstraint;
-
 	UniqueConstraint uc1 = cells[1].get!UniqueConstraint;
 	UniqueConstraint uc2 = cells[2].get!UniqueConstraint;
-	assertTrue(uc0.cells == cells[0 .. 2]);
-	assertTrue(uc1.cells == uc0.cells);
+
+	assertTrue(uc0.cells.equal([cells[1]]));
+	assertTrue(uc1.cells.equal([cells[0]]));
 	assertTrue(uc2 is null);
 
 	UniqueConstraint.createSingle(cells[1], cells[2]);
 	uc2 = cells[2].get!UniqueConstraint;
-	assertTrue(uc1.cells == cells);
+	assertTrue(uc1.cells.equal(cells.filter!(c => c != cells[1])));
 	assertTrue(uc2.cells.length == uc0.cells.length);
 }
 
@@ -153,51 +296,119 @@ unittest
 @("core:constraint:unique: createMultiSingle")
 unittest
 {
+	import core.sudoku.grid : Grid;
 	Cell[] cells1 = [new Cell(2), new Cell(3), new Cell(5)];
 	Cell[] cells2 = [new Cell(2), new Cell(3), new Cell(5)];
-	UniqueConstraint.createMultiSingle(cells1[0], cells1[0 .. 3]);
-	UniqueConstraint.createMultiSingle(cells2[0], cells2[1 .. 3]);
+	UniqueConstraint.createMultiSingle(cells1[0], cells1[0 .. $]);
+	UniqueConstraint.createMultiSingle(cells2[0], cells2[1 .. $]);
 
 	UniqueConstraint uc1 = cells1[0].get!UniqueConstraint;
 	UniqueConstraint uc2 = cells2[0].get!UniqueConstraint;
 
-	import core.sudoku.grid : Grid;
-	assertTrue(Grid.toDigit(uc1.cells) == Grid.toDigit(uc2.cells));
-	assertTrue(uc1.cells.length == 3);
+	assertTrue(Grid.toDigit(uc1.cells).equal(Grid.toDigit(uc2.cells)));
+	assertTrue(uc1.cells.length == 2);
 
 	UniqueConstraint uc3 = cells1[1].get!UniqueConstraint;
-	assertTrue(uc3.cells == cells1[0 .. 2]);
+	assertTrue(uc3.cells.equal([cells1[0]]));
 
 	UniqueConstraint.createMultiSingle(cells1[0], new Cell(6), new Cell(7));
-	assertTrue(uc1.cells.length == 5);
+	assertTrue(uc1.cells.length == 4);
 }
 
 
 @("core:constraint:unique: createInterconnected")
 unittest
 {
+	import std.range : back;
 	Cell[] cells1 = [new Cell(2), new Cell(3), new Cell(5)];
 	UniqueConstraint.createInterconnected(cells1);
 
-	UniqueConstraint uc0 = cells1[0].get!UniqueConstraint;
-	UniqueConstraint uc1 = cells1[1].get!UniqueConstraint;
-	UniqueConstraint uc2 = cells1[2].get!UniqueConstraint;
+	UniqueConstraint uc0 = cells1[0].get!UniqueConstraint; // [3,5]
+	UniqueConstraint uc1 = cells1[1].get!UniqueConstraint; // [2,5]
+	UniqueConstraint uc2 = cells1[2].get!UniqueConstraint; // [2,3]
 
-	import std.algorithm : sort;
-	import std.array : array;
-	assertTrue(uc0.cells == uc1.cells); // [2,3,5]
-	// we need to sort for it to be considered the same array
-	// the logic involved in the construction of the array doesn't sort Cells
-	assertTrue(uc2.cells == [cells1[0], cells1[2], cells1[1]]); // [2,5,3]
-	assertTrue(uc1.cells == sort!((a,b) => a.digit < b.digit)(uc2.cells).array);
+	assertFalse(uc0.cells.equal(uc1.cells));
+	assertTrue(uc2.cells == [cells1[0],cells1[1]]);
 
 	UniqueConstraint.createInterconnected(cells1 ~ new Cell(7));
-	assertTrue(uc0.cells.length == 4);
-	assertTrue(uc0.cells == uc1.cells && uc1.cells == uc2.cells); // [2,3,5,7]
+
+	assertTrue(uc0.cells.length == 3);
+	assertTrue(uc0.cells.back == uc1.cells.back); // [...,7]
 
 	Cell cell = new Cell(10);
-	UniqueConstraint.createInterconnected(cell ~ cells1[0 .. 2]); // [10,2,3]
-	assertTrue(uc0.cells.length == uc1.cells.length); // 5
-	assertTrue(uc0.cells != cell.get!UniqueConstraint.cells);
-	assertTrue(cell.get!UniqueConstraint.cells == cell ~ cells1[0 .. 2]);
+	UniqueConstraint.createInterconnected(cell ~ cells1[0 .. 2]);
+
+	assertTrue(uc0.cells.length == uc1.cells.length); // 4
+	assertFalse(uc0.cells.length == uc2.cells.length); // 4 != 3
+	assertTrue(cell.get!UniqueConstraint.cells.equal(cells1[0 .. 2]));
+}
+
+
+@("core:constraint:unique: removeSingle")
+unittest
+{
+	import std.range : front;
+	Cell cell = new Cell(0);
+	Cell[] cells = [new Cell(2), new Cell(3), new Cell(5)];
+	UniqueConstraint.createMultiSingle(cell, cells);
+	UniqueConstraint.removeSingle(cell, cells.front);
+
+	assertTrue(cell.get!UniqueConstraint.cells.equal(cells[1..$]));
+	assertTrue(cells.front.get!UniqueConstraint is null);
+}
+
+
+@("core:constraint:unique: removeMultiSingle")
+unittest
+{
+	import std.range : front;
+	Cell cell = new Cell(0);
+	Cell[] cells = [new Cell(2), new Cell(3), new Cell(5)];
+	UniqueConstraint.createMultiSingle(cell, cells);
+	UniqueConstraint.removeMultiSingle(cell, cells);
+
+	assertTrue(cell.get!UniqueConstraint is null);
+	assertTrue(cells.front.get!UniqueConstraint is null);
+}
+
+
+@("core:constraint:unique: removeInterconnected")
+unittest
+{
+	import std.algorithm : each;
+	import std.range : back, front;
+	Cell cell = new Cell(0);
+	Cell[] cells = [new Cell(2), new Cell(3), new Cell(5)];
+	UniqueConstraint.createInterconnected(cell ~ cells);
+	UniqueConstraint.removeInterconnected(cells);
+
+	assertTrue(cell.get!UniqueConstraint.cells.equal(cells));
+	assertTrue(cells.each!(c => c.get!UniqueConstraint.cells.equal([cell])));
+}
+
+
+@("core:constraint:unique: takeOut")
+unittest
+{
+	Cell cellOne = new Cell(0);
+	Cell cellTwo = new Cell(0);
+	Cell cellThree = new Cell(0);
+	UniqueConstraint.createMultiSingle(cellOne, [cellTwo, cellThree]);
+	UniqueConstraint.takeOut(cellOne);
+
+	assertTrue(cellOne.get!UniqueConstraint is null);
+	assertTrue(cellTwo.get!UniqueConstraint is null);
+	assertTrue(cellThree.get!UniqueConstraint is null);
+}
+
+
+@("core:constraint:unique: null parameters")
+unittest
+{
+	Cell cellOne = new Cell(0);
+	Cell cellTwo = new Cell(0);
+	Cell cellThree = new Cell(0);
+	UniqueConstraint.createInterconnected(cellOne, null, cellTwo, null, cellThree);
+
+	assertTrue(cellOne.get!UniqueConstraint.cells.equal([cellTwo,cellThree]));
 }

--- a/source/core/rule/rule.d
+++ b/source/core/rule/rule.d
@@ -37,7 +37,7 @@ unittest
 	grid.initialize();
 	grid.addRule(RuleType.Classic);
 
-	assertTrue(grid.toArray().each!(cell => cell.get!UniqueConstraint.cells.length == 8));
+	assertTrue(grid.toArray().each!(cell => cell.get!UniqueConstraint.cells.length == 7));
 }
 
 
@@ -67,7 +67,7 @@ unittest
 	assertTrue(cells.each!(c => canFind(grid.row(0), c)));
 	assertTrue(cells.each!(c => canFind(grid.column(0), c)));
 	assertTrue(cells.each!(c => canFind(grid.box(0).toArray(), c)));
-	assertTrue(cells.length == 8);
+	assertTrue(cells.length == 7);
 
 	assertTrue(grid.toArray().each!(cell => cell.get!UniqueConstraint.cells.length == 8));
 }
@@ -95,11 +95,11 @@ unittest
 
 	auto cells = grid[0,0].get!UniqueConstraint.cells;
 	assertTrue(cells.each!(c => canFind(grid.mainDiagonal(), c)));
-	assertTrue(cells.length == 4);
+	assertTrue(cells.length == 3);
 
 	cells = grid[3,3].get!UniqueConstraint.cells;
 	assertTrue(cells.each!(c => canFind(grid.antiDiagonal(), c)));
-	assertTrue(cells.length == 4);
+	assertTrue(cells.length == 3);
 
 	assertTrue(grid[0,1].get!UniqueConstraint is null);
 }

--- a/source/core/sudoku/cell.d
+++ b/source/core/sudoku/cell.d
@@ -32,11 +32,42 @@ public class Cell
 		{
 			foreach (Cell cell; constraint.cells)
 			{
-				c.add(cell);
+				if (cell != this)
+					c.add(cell);
 			}
 		}
 
 		return c;
+	}
+
+
+	public void disconnect(C : Constraint)(Cell[] cells...)
+	{
+		import std.algorithm : each, remove;
+		import std.range : empty;
+		C constraint = get!C;
+		if (constraint is null)
+			return;
+
+		foreach (cell; cells)
+		{
+			constraint.cells = constraint.cells.remove!(c => c == cell);
+		}
+
+		if (constraint.cells.empty)
+		{
+			constraints = constraints.remove!(c => c == constraint);
+		}
+	}
+
+
+	public void takeOut(C : Constraint)()
+	{
+		C constraint = get!C;
+		if (constraint !is null)
+		{
+			C.takeOut(this);
+		}
 	}
 
 
@@ -85,3 +116,45 @@ public class Cell
 
 	public Constraint[] constraints;
 }
+
+
+version(unittest) { import aurorafw.unit; }
+
+@("core:sudoku:cell: disconnect")
+unittest
+{
+	import std.algorithm : equal;
+	import std.range : empty;
+	import core.constraint : UniqueConstraint;
+	Cell cellOne = new Cell(0);
+	Cell cellTwo = new Cell(0);
+	Cell cellTree = new Cell(0);
+	UniqueConstraint.createMultiSingle(cellOne, [cellTwo, cellTree]);
+	cellOne.disconnect!UniqueConstraint([cellTwo]);
+	cellOne.disconnect!UniqueConstraint([cellTwo]); // no error
+
+	assertTrue(cellOne.get!UniqueConstraint.cells.equal([cellTree]));
+
+	UniqueConstraint constraint = cellOne.get!UniqueConstraint;
+	cellOne.disconnect!UniqueConstraint([cellTree]);
+
+	assertTrue(cellOne.get!UniqueConstraint is null);
+	assertTrue(constraint.cells.empty);
+}
+
+@("core:sudoku:cell: takeOut")
+unittest
+{
+	import core.constraint : UniqueConstraint;
+	Cell cellOne = new Cell(0);
+	Cell cellTwo = new Cell(0);
+	Cell cellThree = new Cell(0);
+	UniqueConstraint.createMultiSingle(cellOne, [cellTwo, cellThree]);
+	cellOne.takeOut!UniqueConstraint;
+
+	assertTrue(cellOne.get!UniqueConstraint is null);
+	assertTrue(cellTwo.get!UniqueConstraint is null);
+	assertTrue(cellThree.get!UniqueConstraint is null);
+}
+
+


### PR DESCRIPTION
```md
Changes:
UniqueConstraint:
  - A Cell constraint doesn't store it's own Cell [1], this is safe to do and doesn't break the solve algorithm
  - Added remove functions

Cell:
  - A Cell can remove Cells from a Constraint: used internally only, calling directly from Cell won't disconnect
     the connected Cells from itself
  - A Cell can remove an entire Constraint from itself safelly [2]

One doubt I have is if I should keep going down this road with the way I'm implementing Constraints.
There's no way of forcing the implementation of static methods in a class, but at the same time it doesn't make
 sense to make a public ctor because of two aspects, each Cell has it's own unique instance of the Constraint
 and if a Cell already has that type of Constraint, the Cells are added to it making the returned instance useless,
 in other words, think of the ctor as a temporary holder for the connections.
These functions will exist in every new Constraint as the connection behavior is the same, the problem with this
 is the implementation will always be the same as well, of course doing it this way there's no other option, but
this is why I'm asking for advise.
If there is a way to improve this, the best time to refactor is now and I gladly accept any opinions. 
```
[1]
```d
Cell cell1 = new Cell(0);
Cell cell2 = new Cell(1);
UniqueConstraint.createSingle(cell1,cell2);
Cell[] cells = cell1.get!UniqueConstraint.cells;
assert(cells.equal([cell1,cell2])); // before
assert(cells.equal([cell2]); // now
```
[2]
```d

Cell cell1 = new Cell(0);
Cell cell2 = new Cell(1);
UniqueConstraint.createSingle(cell1,cell2);
cell1.takeOut!UniqueConstraint; // calls UniqueConstraint.takeOut(cell1);
assert(cell1.get!UniqueConstraint is null);
assert(cell2.get!UniqueConstraint is null);
```

Signed-off-by: João Lourenço <jlourenco5691@gmail.com>