### PR TITLE
Fix core unittests

### DIFF
--- a/source/core/constraint/constraint.d
+++ b/source/core/constraint/constraint.d
@@ -1,7 +1,5 @@
 module core.constraint.constraint;
 
-import std.algorithm : canFind;
-
 import core.constraint.iconstraint;
 import core.sudoku.cell;
 
@@ -13,13 +11,49 @@ public enum ConstraintType : string
 
 public abstract class Constraint : IConstraint
 {
+
 	protected this(ConstraintType constraintType)
 	{
 		_constraintType = constraintType;
 	}
 
-	public abstract void connect(Cell cell);
+
+	///
 	public abstract bool isValid(in int digit);
+
+
+	public static void createSingle(ConstraintType type, Cell cell1, Cell cell2)
+	{
+		final switch(type)
+		{
+			case ConstraintType.Unique:
+				import core.constraint.unique : UniqueConstraint;
+				UniqueConstraint.createSingle(cell1, cell2);
+		}
+	}
+
+
+	public static void createMultiSingle(ConstraintType type, Cell cell, Cell[] cells)
+	{
+		final switch(type)
+		{
+			case ConstraintType.Unique:
+				import core.constraint.unique : UniqueConstraint;
+				UniqueConstraint.createMultiSingle(cell, cells);
+		}
+	}
+
+
+	public static void createInterconnected(ConstraintType type, Cell[] cells)
+	{
+		final switch(type)
+		{
+			case ConstraintType.Unique:
+				import core.constraint.unique : UniqueConstraint;
+				UniqueConstraint.createInterconnected(cells);
+		}
+	}
+
 
 	@safe pure
 	public ConstraintType constraintType() const @property
@@ -27,8 +61,11 @@ public abstract class Constraint : IConstraint
 		return _constraintType;
 	}
 
+
 	public bool add(Cell cell)
 	{
+		import std.algorithm : canFind;
+
 		if (!canFind(cells, cell))
 		{
 			cells ~= cell;

--- a/source/core/constraint/iconstraint.d
+++ b/source/core/constraint/iconstraint.d
@@ -4,6 +4,5 @@ import core.sudoku.cell;
 
 public interface IConstraint
 {
-    public void connect(Cell cell);
-    public bool isValid(in int digit);
+	public bool isValid(in int digit);
 }

--- a/source/core/constraint/unique.d
+++ b/source/core/constraint/unique.d
@@ -1,8 +1,5 @@
 module core.constraint.unique;
 
-import std.algorithm : canFind, map;
-import std.typecons : tuple;
-
 import core.constraint.constraint;
 import core.sudoku.cell;
 
@@ -13,10 +10,9 @@ import core.sudoku.cell;
  */
 public class UniqueConstraint : Constraint
 {
-	private this(Cell cell)
+	public this()
 	{
-		super (ConstraintType.Unique);
-		this.cells ~= cell;
+		super(ConstraintType.Unique);
 	}
 
 
@@ -26,7 +22,8 @@ public class UniqueConstraint : Constraint
 	 * This means when a digit is checked for it's availability in `cell1`
 	 *     the validation is dependent of the digit in `cell2` and vice-versa \
 	 * A Cell cannot connect to itself \
-	 * Null values are not processed
+	 * Null values are not processed \
+	 * Duplicated objected are not processed
 	 *
 	 * Params:
 	 *     cell1 = cell to connect
@@ -40,16 +37,15 @@ public class UniqueConstraint : Constraint
 	 * assert(cell1.get!UniqueConstraint.cells.equal([cell2]));
 	 * assert(cell2.get!UniqueConstraint.cells.equal([cell1]));
 	 * --------------------
+	 *
+	 * SeeAlso: `@Cell` void addConstraint(**C : Constraint**)(**Cell[] cells...**)
 	 */
 	public static void createSingle(Cell cell1, Cell cell2)
 	{
 		if (cell1 is null || cell2 is null || cell1 == cell2)
 			return;
 
-		UniqueConstraint uc1 = new UniqueConstraint(cell2);
-		uc1.connect(cell1);
-		UniqueConstraint uc2 = new UniqueConstraint(cell1);
-		uc2.connect(cell2);
+		cell1.addConstraint!UniqueConstraint(cell2);
 	}
 
 
@@ -58,27 +54,21 @@ public class UniqueConstraint : Constraint
 	 * Ensures `cell` is connected to `cells` and that each Cell in `cells` is
 	 *     connected to `cell` \
 	 * A Cell cannot connect to itself \
-	 * Null values are not processed
+	 * Null values are not processed \
+	 * Duplicated objected are not processed
 	 *
 	 * Params:
 	 *     cell = cell to connect
 	 *     cells = cells to be connected
 	 *
-	 * SeeAlso: void createSingle(**cell1**,**cell2**)
+	 * SeeAlso: `@Cell` void addConstraint(**C : Constraint**)(**Cell[] cells...**)
 	 */
 	public static void createMultiSingle(Cell cell, Cell[] cells...)
 	{
 		if (cell is null)
 			return;
 
-		foreach (Cell c; cells)
-		{
-			if (c is null)
-				continue;
-
-			if (c != cell)
-				createSingle(cell, c);
-		}
+		cell.addConstraint!UniqueConstraint(cells);
 	}
 
 
@@ -86,25 +76,23 @@ public class UniqueConstraint : Constraint
 	 *
 	 * Ensures all Cells in 'cells' are connected to each other \
 	 * A Cell cannot connect to itself \
-	 * Null values are not processed
+	 * Null objects are not processed \
+	 * Duplicated objected are not processed
 	 *
 	 * Params:
 	 *     cells = cells to connect to each other
 	 *
-	 * SeeAlso: void createSingle(**cell1**,**cell2**)
+	 * SeeAlso: `@Cell` void addConstraint(**C : Constraint**)(**Cell[] cells...**)
 	 */
 	public static void createInterconnected(Cell[] cells...)
 	{
 		import std.array : array;
-		import std.algorithm : filter;
-		if (canFind(cells, null))
-		{
-			cells = cells.filter!(cell => cell !is null).array;
-		}
+		import std.algorithm : filter, uniq;
+		cells = uniq(cells.filter!(cell => cell !is null)).array;
 
 		foreach (Cell cell; cells)
 		{
-			createMultiSingle(cell, cells);
+			cell.addConstraint!UniqueConstraint(cells);
 		}
 	}
 
@@ -112,11 +100,14 @@ public class UniqueConstraint : Constraint
 	/** Removes a connection between two Cells
 	 *
 	 * A Cell cannot disconnect from itself \
-	 * Null values are not processed
+	 * Null values are not processed \
+	 * Duplicated objected are not processed
 	 *
 	 * Params:
 	 *     cell1 = cell to disconnect
 	 *     cell2 = cell to disconnect
+	 *
+	 * SeeAlso: `@Cell` void disconnect(**C : Constraint**)(**Cell[] cells...**)
 	 */
 	public static void removeSingle(Cell cell1, Cell cell2)
 	{
@@ -124,68 +115,50 @@ public class UniqueConstraint : Constraint
 			return;
 
 		cell1.disconnect!UniqueConstraint(cell2);
-		cell2.disconnect!UniqueConstraint(cell1);
 	}
 
 
 	/** Removes a connection between a Cell and a group of Cells
 	 *
 	 * A Cell cannot disconnect from itself \
-	 * Null values are not processed
+	 * Null values are not processed \
+	 * Duplicated objected are not processed
 	 *
 	 * Params:
 	 *     cell = cell to disconnect
 	 *     cells = cells to disconnect from
+	 *
+	 * SeeAlso: `@Cell` void disconnect(**C : Constraint**)(**Cell[] cells...**)
 	 */
 	public static void removeMultiSingle(Cell cell, Cell[] cells...)
 	{
-		foreach (c; cells)
-		{
-			if (c is null)
-				continue;
+		if (cell is null)
+			return;
 
-			if (c != cell)
-				removeSingle(cell, c);
-		}
+		cell.disconnect!UniqueConstraint(cells);
 	}
 
 
 	/** Removes a connection between Cells
 	 *
 	 * A Cell cannot disconnect from itself \
-	 * Null values are not processed
+	 * Null values are not processed \
+	 * Duplicated objected are not processed
 	 *
 	 * Params:
 	 *     cells = cells to disconnect from each other
+	 *
+	 * SeeAlso: `@Cell` void disconnect(**C : Constraint**)(**Cell[] cells...**)
 	 */
 	public static void removeInterconnected(Cell[] cells...)
 	{
 		import std.array : array;
 		import std.algorithm : filter;
-		if (canFind(cells, null))
-		{
-			cells = cells.filter!(cell => cell !is null).array;
-		}
+		cells = cells.filter!(cell => cell !is null).array;
 
 		foreach (Cell cell; cells)
 		{
-			removeMultiSingle(cell, cells);
-		}
-	}
-
-
-	/** Removes a UniqueConstraint from a Cell
-	 *
-	 * Ensures all Cells connected to `cell` are disconnected from it aswell
-	 *
-	 * Params:
-	 *     cell = cell to remove UniqueConstraint
-	 */
-	public static void takeOut(Cell cell)
-	{
-		foreach (c; cell.get!UniqueConstraint.cells)
-		{
-			removeSingle(c, cell);
+			cell.disconnect!UniqueConstraint(cells);
 		}
 	}
 
@@ -196,17 +169,6 @@ public class UniqueConstraint : Constraint
 		return ConstraintType.Unique;
 	}
 
-
-	/** Connect a Cell to this Constraint
-	 *
-	 * Params:
-	 *     cell = Cell to connect
-	 */
-	override
-	public void connect(Cell cell)
-	{
-		cell.connect(this);
-	}
 
 	/** Search for the same digit
 	 *
@@ -223,6 +185,7 @@ public class UniqueConstraint : Constraint
 	override
 	public bool isValid(in int digit)
 	{
+		import std.algorithm : canFind, map;
 		return !canFind(cells.map!(x => x.digit), digit);
 	}
 }
@@ -241,40 +204,42 @@ unittest
 	UniqueConstraint.createInterconnected(cells);
 
 	UniqueConstraint constraint = cells[0].get!UniqueConstraint;
-	assertTrue(constraint !is null);
+
+	assertNotNull(constraint);
 	assertTrue(constraint.isValid(4));
 	assertFalse(constraint.isValid(0));
 }
 
-
 @("core:constraint:unique: connect")
 unittest
 {
+	import std.algorithm : canFind;
+
 	Cell[] cells = [new Cell(4), new Cell(0)];
 	UniqueConstraint.createInterconnected(cells);
 
 	Cell cell = new Cell(2);
 	UniqueConstraint.createMultiSingle(cell, cells);
-
 	UniqueConstraint uc0 = cells[0].get!UniqueConstraint;
+
 	assertTrue(canFind(uc0.cells, cell));
 	assertTrue(uc0.isValid(1));
 	assertFalse(uc0.isValid(2));
 
 	UniqueConstraint uc1 = cells[1].get!UniqueConstraint;
 	UniqueConstraint uc2 = cell.get!UniqueConstraint;
-	assertTrue(uc0 != uc1 && uc1 != uc2);
 
-
+	assertNotSame(uc0, uc1);
+	assertNotSame(uc1, uc2);
 	assertFalse(uc0.cells.equal(uc1.cells));
 	assertTrue(uc0.cells.equal(cells[1..$] ~ cell));
 }
-
 
 @("core:constraint:unique: createSingle")
 unittest
 {
 	import std.algorithm : filter;
+
 	Cell[] cells = [new Cell(2), new Cell(3), new Cell(5)];
 	UniqueConstraint.createSingle(cells[0], cells[1]);
 
@@ -284,14 +249,14 @@ unittest
 
 	assertTrue(uc0.cells.equal([cells[1]]));
 	assertTrue(uc1.cells.equal([cells[0]]));
-	assertTrue(uc2 is null);
+	assertNull(uc2);
 
 	UniqueConstraint.createSingle(cells[1], cells[2]);
 	uc2 = cells[2].get!UniqueConstraint;
-	assertTrue(uc1.cells.equal(cells.filter!(c => c != cells[1])));
-	assertTrue(uc2.cells.length == uc0.cells.length);
-}
 
+	assertTrue(uc1.cells.equal(cells.filter!(c => c != cells[1])));
+	assertEquals(uc2.cells.length, uc0.cells.length);
+}
 
 @("core:constraint:unique: createMultiSingle")
 unittest
@@ -306,20 +271,22 @@ unittest
 	UniqueConstraint uc2 = cells2[0].get!UniqueConstraint;
 
 	assertTrue(Grid.toDigit(uc1.cells).equal(Grid.toDigit(uc2.cells)));
-	assertTrue(uc1.cells.length == 2);
+	assertEquals(uc1.cells.length, 2);
 
 	UniqueConstraint uc3 = cells1[1].get!UniqueConstraint;
+
 	assertTrue(uc3.cells.equal([cells1[0]]));
 
 	UniqueConstraint.createMultiSingle(cells1[0], new Cell(6), new Cell(7));
-	assertTrue(uc1.cells.length == 4);
-}
 
+	assertEquals(uc1.cells.length, 4);
+}
 
 @("core:constraint:unique: createInterconnected")
 unittest
 {
 	import std.range : back;
+
 	Cell[] cells1 = [new Cell(2), new Cell(3), new Cell(5)];
 	UniqueConstraint.createInterconnected(cells1);
 
@@ -328,79 +295,67 @@ unittest
 	UniqueConstraint uc2 = cells1[2].get!UniqueConstraint; // [2,3]
 
 	assertFalse(uc0.cells.equal(uc1.cells));
-	assertTrue(uc2.cells == [cells1[0],cells1[1]]);
+	assertTrue(uc2.cells.equal([cells1[0],cells1[1]]));
 
 	UniqueConstraint.createInterconnected(cells1 ~ new Cell(7));
 
-	assertTrue(uc0.cells.length == 3);
-	assertTrue(uc0.cells.back == uc1.cells.back); // [...,7]
+	assertEquals(uc0.cells.length, 3);
+	assertSame(uc0.cells.back, uc1.cells.back); // [...,7]
 
 	Cell cell = new Cell(10);
 	UniqueConstraint.createInterconnected(cell ~ cells1[0 .. 2]);
 
-	assertTrue(uc0.cells.length == uc1.cells.length); // 4
+	assertEquals(uc0.cells.length, uc1.cells.length); // 4
 	assertFalse(uc0.cells.length == uc2.cells.length); // 4 != 3
 	assertTrue(cell.get!UniqueConstraint.cells.equal(cells1[0 .. 2]));
 }
-
 
 @("core:constraint:unique: removeSingle")
 unittest
 {
 	import std.range : front;
+
 	Cell cell = new Cell(0);
 	Cell[] cells = [new Cell(2), new Cell(3), new Cell(5)];
+
 	UniqueConstraint.createMultiSingle(cell, cells);
 	UniqueConstraint.removeSingle(cell, cells.front);
 
 	assertTrue(cell.get!UniqueConstraint.cells.equal(cells[1..$]));
-	assertTrue(cells.front.get!UniqueConstraint is null);
+	assertNull(cells.front.get!UniqueConstraint);
 }
 
 
 @("core:constraint:unique: removeMultiSingle")
 unittest
 {
-	import std.range : front;
+	import std.algorithm : each;
+
 	Cell cell = new Cell(0);
 	Cell[] cells = [new Cell(2), new Cell(3), new Cell(5)];
+
 	UniqueConstraint.createMultiSingle(cell, cells);
 	UniqueConstraint.removeMultiSingle(cell, cells);
 
-	assertTrue(cell.get!UniqueConstraint is null);
-	assertTrue(cells.front.get!UniqueConstraint is null);
+	assertNull(cell.get!UniqueConstraint);
+	cells.each!(c => assertNull(c.get!UniqueConstraint));
 }
-
 
 @("core:constraint:unique: removeInterconnected")
 unittest
 {
 	import std.algorithm : each;
 	import std.range : back, front;
+
 	Cell cell = new Cell(0);
 	Cell[] cells = [new Cell(2), new Cell(3), new Cell(5)];
+
 	UniqueConstraint.createInterconnected(cell ~ cells);
 	UniqueConstraint.removeInterconnected(cells);
 
 	assertTrue(cell.get!UniqueConstraint.cells.equal(cells));
-	assertTrue(cells.each!(c => c.get!UniqueConstraint.cells.equal([cell])));
+	cells.each!(c => assertTrue(c.get!UniqueConstraint.cells.equal([cell])));
 }
-
-
-@("core:constraint:unique: takeOut")
-unittest
-{
-	Cell cellOne = new Cell(0);
-	Cell cellTwo = new Cell(0);
-	Cell cellThree = new Cell(0);
-	UniqueConstraint.createMultiSingle(cellOne, [cellTwo, cellThree]);
-	UniqueConstraint.takeOut(cellOne);
-
-	assertTrue(cellOne.get!UniqueConstraint is null);
-	assertTrue(cellTwo.get!UniqueConstraint is null);
-	assertTrue(cellThree.get!UniqueConstraint is null);
-}
-
 
 @("core:constraint:unique: null parameters")
 unittest
@@ -408,7 +363,9 @@ unittest
 	Cell cellOne = new Cell(0);
 	Cell cellTwo = new Cell(0);
 	Cell cellThree = new Cell(0);
+
 	UniqueConstraint.createInterconnected(cellOne, null, cellTwo, null, cellThree);
 
 	assertTrue(cellOne.get!UniqueConstraint.cells.equal([cellTwo,cellThree]));
 }
+

--- a/source/core/rule/classic.d
+++ b/source/core/rule/classic.d
@@ -1,0 +1,87 @@
+module core.rule.classic;
+
+import core.constraint.constraint : ConstraintType;
+import core.rule.rule;
+import core.sudoku.cell;
+import core.sudoku.grid;
+
+public class ClassicRule : Rule
+{
+	private this(Cell[][ConstraintType] cells...)
+	{
+		super (RuleType.Classic, cells);
+	}
+
+
+	/** Adds ClassicRule to a Grid
+	 *
+	 * Classic rule requires the following constraints:
+	 * * each Cell in a row must be unique
+	 * * each Cell in a column must be unique
+	 * * each Cell in a box must be unique
+	 *
+	 * Params:
+	 *     grid = Grid in which this rule will be added
+	 */
+	public static void create(Grid grid)
+	{
+		import std.algorithm : canFind, filter, uniq;
+		import std.array : array;
+		import core.constraint.unique : UniqueConstraint;
+
+		Cell[] cells = grid.toArray();
+		if (canFind(cells, null))
+			return;
+
+		if (RuleType.Classic in grid[0,0].rules)
+			return;
+
+		for (int y; y < grid.rows; y++)
+		{
+			Cell[] rows = grid.row(y);
+			for (int x; x < grid.columns; x++)
+			{
+				Cell[] columns = grid.column(x);
+				Cell[] box = grid.boxes[y/grid.boxRows][x/grid.boxColumns].toArray();
+
+				Cell[][ConstraintType] needed;
+				needed[ConstraintType.Unique] = uniq(rows~columns~box)
+												.filter!(c => c != grid[y,x] && c !is null)
+												.array;
+
+				grid[y,x].addConstraint!UniqueConstraint(needed[ConstraintType.Unique]);
+				grid[y,x].rules[RuleType.Classic] = new ClassicRule(needed);
+			}
+		}
+	}
+
+
+	public static RuleType getStaticRuleType()
+	{
+		return RuleType.Classic;
+	}
+}
+
+
+version(unittest) { import aurorafw.unit; }
+
+@("core:rule:ruleClassic: create")
+unittest
+{
+	import std.algorithm : canFind, each, uniq;
+	import std.array : array;
+	import std.range : chain;
+	import core.constraint.unique : UniqueConstraint;
+
+	Grid grid = new Grid(SudokuType.Sudoku4x4);
+	grid.initialize();
+
+	ClassicRule.create(grid);
+	Cell[] connected = grid[0,0].get!UniqueConstraint.cells;
+	Cell[] cells = uniq(chain(grid.row(0),grid.column(0),grid.box(0).toArray())).array;
+
+	connected.each!(cell => assertTrue(canFind(cells, cell)));
+	assertEquals(connected.length, 7);
+
+	grid.toArray().each!(cell => assertEquals(cell.get!UniqueConstraint.cells.length, 7));
+}

--- a/source/core/rule/package.d
+++ b/source/core/rule/package.d
@@ -1,0 +1,5 @@
+module core.rule;
+
+public import core.rule.rule;
+public import core.rule.classic;
+public import core.rule.x;

--- a/source/core/rule/rule.d
+++ b/source/core/rule/rule.d
@@ -1,9 +1,7 @@
 module core.rule.rule;
 
-import std.algorithm : each;
-import std.range : iota;
-
 import core.constraint;
+import core.sudoku.cell;
 import core.sudoku.grid;
 
 public enum RuleType
@@ -12,94 +10,186 @@ public enum RuleType
 	X,
 }
 
-version(unittest)
+public class Rule
 {
-	import aurorafw.unit;
-	import core.constraint;
-	import core.sudoku.cell;
-	import core.sudoku.grid;
-	import std.algorithm : canFind;
-}
-
-public void addRule(Grid grid, RuleType rule)
-{
-	final switch(rule)
+	protected this(RuleType type, Cell[][ConstraintType] cells...)
 	{
-		case RuleType.Classic: addRuleClassic(grid); break;
-		case RuleType.X: addRuleX(grid); break;
+		_ruleType = ruleType;
+		this.cells = cells;
 	}
+
+
+	/** Adds a rule to a grid
+	 *
+	 * Calls the create method from the RuleType passed.\
+	 * A rule is nothing more than a group of Constraints. \
+	 * Rules are stored individualy in each Cell with only the Cells that are
+	 *     connected by that Cell. \
+	 * This means that each Cell of a 4x4 sudoku with the Classic rule,
+	 *     will have a Classic rule containing only the 3 other Cells in that row,
+	 *     column and the left one in that box under the UniqueConstraint.
+	 *
+	 * Params:
+	 *     type = RuleType to add
+	 *     grid = Grid to in which type will be added
+	 */
+	public static void create(RuleType type, Grid grid)
+	{
+		final switch(type)
+		{
+			case RuleType.Classic:
+				import core.rule.classic : ClassicRule;
+				ClassicRule.create(grid);
+				break;
+
+			case RuleType.X:
+				import core.rule.x : XRule;
+				XRule.create(grid);
+				break;
+		}
+	}
+
+
+	/** Removes a rule from a grid
+	 *
+	 * Safely removes a rule from each Cell \
+	 * It checks if this type's cells are common to other rules in the same
+	 *     Cell under the same Constraint and preserves them \
+	 * \
+	 * For example, let's a Grid has the Classic and X rules, this means every
+	 *     Cell in the grid has the UniqueConstraint for every row,
+	 *     column and in which they exist, and adicionaly diagonal Cells have
+	 *     the UniqueConstraint for the diagonal in which they exist. \
+	 * This creates dependencies or common Cells between this two rules, every
+	 *     diagonal Cell is common between them. \
+	 * If we only remove the rule without searching for these common Cells,
+	 *     the remaining rules will be broken. \
+	 * If we a 4x4 sudoku with these rules and remove X, leaving only Classic,
+	 *     it'll disconnect every diagonal Cell from each other, leaving the
+	 *     Classic rule broken beacause of missing constraints in some Cells,
+	 *     the diagonal Cells in the same box.
+	 *
+	 * Params:
+	 *     type = RuleType to remove
+	 *     grid = Grid in which type will be removed
+	 */
+	public static void remove(RuleType type, Grid grid)
+	{
+		import std.algorithm : canFind, filter, setIntersection, map;
+		import std.array : array;
+		import std.range : empty;
+
+		Cell[] cells = grid.toArray();
+		if (canFind(cells, null))
+			return;
+
+		// get cells with rule
+		Cell[] cellsWithRule = cells.filter!(cell => type in cell.rules).array;
+
+		foreach (cell; cellsWithRule)
+		{
+			// get the cells within the rule
+			Cell[][ConstraintType] ruleCells = cell.rules[type].cells;
+
+			// get other rules
+			RuleType[] ruleTypes = cell.rules.keys.filter!(key => key != type).array;
+
+			if (ruleTypes.empty)
+			{
+				foreach (ConstraintType constraint; ruleCells.keys)
+				{
+					cell.disconnect(constraint, ruleCells[constraint]);
+				}
+				cell.rules.remove(type);
+				continue;
+			}
+
+			foreach (ruleType; ruleTypes)
+			{
+				// loop ruleCells constraints
+				foreach (ConstraintType constraint; ruleCells.keys)
+				{
+					if (!canFind(cell.rules[ruleType].cells.keys, constraint))
+					{
+						cell.disconnect(constraint, ruleCells[constraint]);
+					}
+					else
+					{
+						Cell[] difference = ruleCells[constraint]
+												.filter!(c => !canFind(cell.rules[ruleType].cells[constraint], c))
+												.array;
+						cell.disconnect(constraint, difference);
+					}
+				}
+			}
+
+			cell.rules.remove(type);
+		}
+	}
+
+
+	public RuleType ruleType() const @property
+	{
+		return _ruleType;
+	}
+
+
+	public Cell[][ConstraintType] cells;
+	protected RuleType _ruleType;
 }
 
-@("core:rule:rule: addRule")
+
+version(unittest) { import aurorafw.unit; }
+
+@("core:rule:rule: remove")
 unittest
 {
+	import std.algorithm : each;
+
 	Grid grid = new Grid(SudokuType.Sudoku4x4);
 	grid.initialize();
-	grid.addRule(RuleType.Classic);
 
-	assertTrue(grid.toArray().each!(cell => cell.get!UniqueConstraint.cells.length == 7));
+	Rule.create(RuleType.Classic, grid);
+	Rule.remove(RuleType.Classic, grid);
+
+	grid.toArray().each!(cell => assertNull(cell.get!UniqueConstraint));
+
+	Rule.create(RuleType.X, grid);
+	Rule.remove(RuleType.X, grid);
+
+	grid.toArray().each!(cell => assertNull(cell.get!UniqueConstraint));
 }
 
-
-/** Classic Rule initializer
- *
- * Runs and inits every Constraint which satisfacts this Rule:
- * * UniqueConstraint for every row
- * * UniqueConstraint for every column
- * * UniqueConstraint for every box
- */
-public void addRuleClassic(Grid grid)
-{
-		// rows, columns, boxes
-		iota(grid.rows).each!(i => UniqueConstraint.createInterconnected(grid.row(i)));
-		iota(grid.columns).each!(i => UniqueConstraint.createInterconnected(grid.column(i)));
-		iota(grid.rows).each!(i => UniqueConstraint.createInterconnected(grid.box(i).toArray()));
-}
-
-@("core:rule:rule: addRuleClassic")
+@("core:rule:rule: remove with dependencies")
 unittest
 {
+	import std.algorithm : canFind, each, equal, filter;
+	import std.array : array;
+	import std.range : chain;
+
 	Grid grid = new Grid(SudokuType.Sudoku4x4);
 	grid.initialize();
-	addRuleClassic(grid);
 
-	auto cells = grid[0,0].get!UniqueConstraint.cells;
-	assertTrue(cells.each!(c => canFind(grid.row(0), c)));
-	assertTrue(cells.each!(c => canFind(grid.column(0), c)));
-	assertTrue(cells.each!(c => canFind(grid.box(0).toArray(), c)));
-	assertTrue(cells.length == 7);
+	Rule.create(RuleType.Classic, grid);
+	Rule.create(RuleType.X, grid);
 
-	assertTrue(grid.toArray().each!(cell => cell.get!UniqueConstraint.cells.length == 8));
-}
+	// removing this rule only disconnects the cells not common
+	//  to other rules with the same constraints
+	Rule.remove(RuleType.Classic, grid);
 
+	Cell[] cells = grid.mainDiagonal();
 
-/** X Rule initializer
- *
- * Runs and inits every Constraint which satisfacts this Rule:
- * * UniqueConstraint for main diagonal
- * * UniqueConstraint for antidiagonal
- */
-public void addRuleX(Grid grid)
-{
-	// both diagonals
-	UniqueConstraint.createInterconnected(grid.mainDiagonal());
-	UniqueConstraint.createInterconnected(grid.antiDiagonal());
-}
+	cells.each!(cell => cell.get(ConstraintType.Unique).cells.equal(cells.filter!(c => c != cell)));
+	cells.each!(cell => assertEquals(cell.get(ConstraintType.Unique).cells.length, 3));
 
-@("core:rule:rule: addRuleX")
-unittest
-{
-	Grid grid = new Grid(SudokuType.Sudoku4x4);
-	grid.initialize();
-	addRuleX(grid);
+	cells = grid.antiDiagonal();
 
-	auto cells = grid[0,0].get!UniqueConstraint.cells;
-	assertTrue(cells.each!(c => canFind(grid.mainDiagonal(), c)));
-	assertTrue(cells.length == 3);
+	cells.each!(cell => cell.get(ConstraintType.Unique).cells.equal(cells.filter!(c => c != cell)));
+	cells.each!(cell => assertEquals(cell.get(ConstraintType.Unique).cells.length, 3));
 
-	cells = grid[3,3].get!UniqueConstraint.cells;
-	assertTrue(cells.each!(c => canFind(grid.antiDiagonal(), c)));
-	assertTrue(cells.length == 3);
+	Cell[] connected = chain(grid.mainDiagonal(),grid.antiDiagonal()).array;
+	cells = grid.toArray().filter!(cell => !canFind(connected, cell)).array;
 
-	assertTrue(grid[0,1].get!UniqueConstraint is null);
+	// test every cell not in the diagonals
+	cells.each!(cell => assertNull(cell.get!UniqueConstraint));
 }

--- a/source/core/rule/x.d
+++ b/source/core/rule/x.d
@@ -1,0 +1,102 @@
+module core.rule.x;
+
+import core.constraint.constraint : ConstraintType;
+import core.rule.rule;
+import core.sudoku.cell;
+import core.sudoku.grid;
+
+public class XRule : Rule
+{
+	private this(Cell[][ConstraintType] cells...)
+	{
+		super(RuleType.X, cells);
+	}
+
+
+	/** Adds XRule to a Grid
+	 *
+	 * X rule requires the following constraints:
+	 * * each Cell in the main diagonal must be unique
+	 * * each Cell in the antidiagonal must be unique
+	 *
+	 * Params:
+	 *     grid = Grid in which this rule will be added
+	 */
+	public static void create(Grid grid)
+	{
+		import std.algorithm : canFind, filter, uniq;
+		import std.array : array;
+		import core.constraint.unique : UniqueConstraint;
+
+		if (canFind(grid.toArray(), null))
+			return;
+
+		if (RuleType.X in grid[0,0].rules)
+			return;
+
+		Cell[] cells = grid.mainDiagonal();
+		foreach (Cell cell; cells)
+		{
+			Cell[][ConstraintType] needed;
+			needed[ConstraintType.Unique] = cells
+											.filter!(c => c != cell)
+											.array;
+
+			cell.addConstraint!UniqueConstraint(needed[ConstraintType.Unique]);
+			cell.rules[RuleType.X] = new XRule(needed);
+		}
+
+		cells = grid.antiDiagonal();
+		foreach (Cell cell; cells)
+		{
+			Cell[][ConstraintType] needed;
+			needed[ConstraintType.Unique] = cells
+											.filter!(c => c != cell)
+											.array;
+
+			cell.addConstraint!UniqueConstraint(needed[ConstraintType.Unique]);
+			cell.rules[RuleType.X] = new XRule(needed);
+		}
+	}
+
+
+	public static RuleType getStaticRuleType()
+	{
+		return RuleType.X;
+	}
+}
+
+
+version(unittest) { import aurorafw.unit; }
+
+@("core:rule:xRule: create")
+unittest
+{
+	import std.algorithm : canFind, each, filter;
+	import std.array : array;
+	import std.range : chain;
+	import core.constraint.unique : UniqueConstraint;
+
+	Grid grid = new Grid(SudokuType.Sudoku4x4);
+	grid.initialize();
+
+	XRule.create(grid);
+
+	Cell[] connected = grid[0,0].get!UniqueConstraint.cells;
+	Cell[] cells = grid.mainDiagonal();
+
+	connected.each!(cell => assertTrue(canFind(cells, cell)));
+	assertEquals(connected.length, 3);
+
+	connected = grid[0,3].get!UniqueConstraint.cells;
+	cells = grid.antiDiagonal();
+
+	connected.each!(cell => assertTrue(canFind(cells, cell)));
+	assertEquals(connected.length, 3);
+
+	connected = chain(grid.mainDiagonal(),grid.antiDiagonal()).array;
+	cells = grid.toArray().filter!(cell => !canFind(connected, cell)).array;
+
+	// test every cell not in the diagonals
+	cells.each!(cell => assertNull(cell.get!UniqueConstraint));
+}

--- a/source/core/sudoku/box.d
+++ b/source/core/sudoku/box.d
@@ -1,7 +1,5 @@
 module core.sudoku.box;
 
-import std.array: join;
-
 import core.sudoku.cell;
 import core.sudoku.grid;
 

--- a/source/core/sudoku/box.d
+++ b/source/core/sudoku/box.d
@@ -52,3 +52,52 @@ public class Box
 	public const int columns;
 	public const int rows;
 }
+
+
+version(unittest) { import aurorafw.unit; }
+
+version(unittest)
+{
+	Cell[][] cells = [[new Cell(0),new Cell(1)],[new Cell(2),new Cell(3)]];
+}
+
+
+@("core:sudoku:box: initialize")
+unittest
+{
+	import std.algorithm : each;
+	import std.range : join;
+
+	Box box = new Box(2,2);
+
+	box.cells.join.each!(cell => assertNull(cell));
+
+	box.initialize(cells);
+
+	box.cells.join.each!(cell => assertNotNull(cell));
+	assertSame(box.cells, cells);
+}
+
+@("core:sudoku:box: toArray")
+unittest
+{
+	import std.algorithm : equal;
+	import std.range : join;
+
+	Box box = new Box(2,2);
+	box.initialize(cells);
+
+	assertTrue(box.toArray().equal(cells.join));
+}
+
+@("core:sudoku:box: toDigit")
+unittest
+{
+	import std.algorithm : each;
+	import std.range : join;
+
+	Box box = new Box(2,2);
+	box.initialize(cells);
+
+	box.toDigit.join.each!((i, ref digit) => assertEquals(digit, cells.join[i].digit));
+}

--- a/source/core/sudoku/cell.d
+++ b/source/core/sudoku/cell.d
@@ -1,6 +1,6 @@
 module core.sudoku.cell;
 
-import core.constraint.constraint;
+import core.constraint;
 
 public class Cell
 {
@@ -11,75 +11,162 @@ public class Cell
 	}
 
 
-	/** Connects Cell to a Constraint
+	/** Safely adds a constraint
+	 *
+	 * It filters any invalid data passed in `cells`, null values, duplicated objects,
+	 *     same Cell as the being used
 	 *
 	 * Params:
-	 *     constraint = constraint to connect
+	 *     C = Constraint to add
+	 *     cells = cells to connect under C
 	 */
-	public auto connect(C : Constraint)(C constraint)
+	public void addConstraint(C : Constraint)(Cell[] cells...)
 	{
-		import std.algorithm : canFind;
-		if (constraint is null)
-			return null;
+		// remove null and repeated cells
+		import std.algorithm : canFind, filter, uniq;
+		import std.array : array;
 
-		C c = get!C;
-		if (c is null)
+		cells = uniq(cells.filter!(cell => cell !is null && cell != this)).array;
+		ConstraintType type = C.getStaticConstraintType;
+
+		// create a new instance if this Cell doesn't containt this ConstraintType
+		if (type !in constraints)
 		{
-			constraints ~= constraint;
-			c = constraint;
+			constraints[type] = new C();
 		}
-		else
+
+		// add and connect to non existent Cells
+		foreach (cell; cells)
 		{
-			foreach (Cell cell; constraint.cells)
+			if (!canFind(constraints[type].cells, cell))
 			{
-				if (cell != this)
-					c.add(cell);
+				constraints[type].cells ~= cell;
+				cell.addConstraint!C(this);
+			}
+		}
+	}
+
+
+	/** safely adds a constraint
+	 *
+	 * Adds a constraint by its type \
+	 * It filters any invalid data passed in `cells`, null values, duplicated objects,
+	 *     same Cell as the being used
+	 *
+	 * Params:
+	 *     type = ConstraintType to add
+	 *     cells = Cells to connect
+	 *
+	 * SeeAlso: void addConstraint(**C : Constraint**)(**Cell[] cells...**)
+	 */
+	public void addConstraint(ConstraintType type, Cell[] cells...)
+	{
+		Constraint.createMultiSingle(type, this, cells);
+	}
+
+
+	/** Safely removes a constraint from a Cell
+	 *
+	 * It disconnects all the connected Cells from each other
+	 *
+	 * Params:
+	 *     type = ContraintType to remove
+	 *
+	 * SeeAlso: void disconnect(**ConstraintType type, **Cell[] cells...**)
+	 */
+	public void removeConstraint(ConstraintType type)
+	{
+		if (type !in constraints)
+			return;
+
+		// safely cut the connection between both Cells
+		disconnect(type, constraints[type].cells);
+	}
+
+
+	/** Safely removes a constraint from a Cell
+	 *
+	 * Params:
+	 *     C = Contraint to remove
+	 *
+	 * SeeAlso: void removeConstraint(**ConstraintType type**)
+	 */
+	public void removeConstraint(C : Constraint)()
+	{
+		removeConstraint(C.getStaticConstraintType);
+	}
+
+
+	/** Safely disconnects Cells from each other
+	 *
+	 * It filters any invalid data passed in `cells`, null values, duplicated objects,
+	 *     same Cell as the being used
+	 *
+	 * Params:
+	 *     type = ConstraintType to use
+	 *     cells = cells to disconnect
+	 */
+	public void disconnect(ConstraintType type, Cell[] cells...)
+	{
+		import std.algorithm : canFind, each, filter, remove, uniq;
+		import std.array : array;
+		import std.range : empty;
+
+		cells = uniq(cells.filter!(cell => cell !is null && cell != this)).array;
+
+		// check if Cell has this constraint
+		if (type !in constraints)
+			return;
+
+		// safely disconnect existent cells from each other
+		foreach (cell; cells)
+		{
+			if (type in constraints && canFind(constraints[type].cells, cell))
+			{
+				constraints[type].cells = constraints[type].cells.remove!(c => c == cell);
+				cell.disconnect(type, this);
 			}
 		}
 
-		return c;
+		// here we need to verify if the constraint has been removed already
+		if (type in constraints && constraints[type].cells.empty)
+		{
+			constraints.remove(type);
+		}
 	}
 
 
+	/** Safely disconnects Cells from each other
+	 *
+	 * Params:
+	 *     C = Constraint to use
+	 *     cells = cells to disconnect
+	 *
+	 * SeeAlso: void disconnect(**ConstraintType type, **Cell[] cells...**)
+	 */
 	public void disconnect(C : Constraint)(Cell[] cells...)
 	{
-		import std.algorithm : each, remove;
-		import std.range : empty;
-		C constraint = get!C;
-		if (constraint is null)
-			return;
-
-		foreach (cell; cells)
-		{
-			constraint.cells = constraint.cells.remove!(c => c == cell);
-		}
-
-		if (constraint.cells.empty)
-		{
-			constraints = constraints.remove!(c => c == constraint);
-		}
-	}
-
-
-	public void takeOut(C : Constraint)()
-	{
-		C constraint = get!C;
-		if (constraint !is null)
-		{
-			C.takeOut(this);
-		}
+		disconnect(C.getStaticConstraintType, cells);
 	}
 
 
 	@safe
 	public C get(C : Constraint)()
 	{
-		foreach (Constraint c; constraints)
-		{
-			if (c.constraintType == C.getStaticConstraintType())
-				return cast(C) c;
-		}
-		return null;
+		if (C.getStaticConstraintType() !in constraints)
+			return null;
+
+		return cast(C) constraints[C.getStaticConstraintType];
+	}
+
+
+	@safe
+	public auto get(ConstraintType type)
+	{
+		if (type !in constraints)
+			return null;
+
+		return constraints[type];
 	}
 
 
@@ -114,47 +201,131 @@ public class Cell
 	public const bool isBlocked;
 	public int digit;
 
-	public Constraint[] constraints;
+	public Constraint[ConstraintType] constraints;
 }
 
 
 version(unittest) { import aurorafw.unit; }
 
+@("core:sudoku:cell: addConstraint")
+unittest
+{
+	import std.algorithm : each, equal;
+	import core.constraint : UniqueConstraint;
+
+	Cell cellOne = new Cell(0);
+	Cell cellTwo = new Cell(0);
+	Cell cellTree = new Cell(0);
+
+	cellOne.addConstraint!UniqueConstraint(cellTwo,cellTree);
+
+	assertTrue(cellOne.get!UniqueConstraint.cells.equal([cellTwo, cellTree]));
+	[cellTwo, cellTree].each!(cell => assertTrue(cell.get!UniqueConstraint.cells.equal([cellOne])));
+}
+
+@("core:sudoku:cell: addConstraint filters")
+unittest
+{
+	import std.algorithm : equal;
+	import core.constraint : UniqueConstraint;
+
+	Cell cellOne = new Cell(0);
+	Cell cellTwo = new Cell(0);
+	cellOne.addConstraint!UniqueConstraint(cellOne,null,cellTwo,null,cellTwo);
+
+	assertTrue(cellOne.get!UniqueConstraint.cells.equal([cellTwo]));
+	assertTrue(cellTwo.get!UniqueConstraint.cells.equal([cellOne]));
+}
+
 @("core:sudoku:cell: disconnect")
 unittest
 {
 	import std.algorithm : equal;
-	import std.range : empty;
 	import core.constraint : UniqueConstraint;
+
 	Cell cellOne = new Cell(0);
 	Cell cellTwo = new Cell(0);
 	Cell cellTree = new Cell(0);
-	UniqueConstraint.createMultiSingle(cellOne, [cellTwo, cellTree]);
-	cellOne.disconnect!UniqueConstraint([cellTwo]);
-	cellOne.disconnect!UniqueConstraint([cellTwo]); // no error
+
+	cellOne.addConstraint!UniqueConstraint(cellTwo,cellTree);
+	cellOne.disconnect!UniqueConstraint(cellTwo);
+	cellOne.disconnect!UniqueConstraint(cellTwo); // no error
 
 	assertTrue(cellOne.get!UniqueConstraint.cells.equal([cellTree]));
+	assertNull(cellTwo.get!UniqueConstraint);
 
 	UniqueConstraint constraint = cellOne.get!UniqueConstraint;
 	cellOne.disconnect!UniqueConstraint([cellTree]);
 
-	assertTrue(cellOne.get!UniqueConstraint is null);
-	assertTrue(constraint.cells.empty);
+	assertNull(cellOne.get!UniqueConstraint);
+	assertNull(cellTree.get!UniqueConstraint);
+	assertEmpty(constraint.cells);
 }
 
-@("core:sudoku:cell: takeOut")
+@("core:sudoku:cell: disconnect filters")
 unittest
 {
+	import std.algorithm : equal;
 	import core.constraint : UniqueConstraint;
+
 	Cell cellOne = new Cell(0);
 	Cell cellTwo = new Cell(0);
 	Cell cellThree = new Cell(0);
-	UniqueConstraint.createMultiSingle(cellOne, [cellTwo, cellThree]);
-	cellOne.takeOut!UniqueConstraint;
+	cellOne.addConstraint!UniqueConstraint(cellTwo);
+	cellOne.disconnect!UniqueConstraint(cellOne,null,null,cellThree);
 
-	assertTrue(cellOne.get!UniqueConstraint is null);
-	assertTrue(cellTwo.get!UniqueConstraint is null);
-	assertTrue(cellThree.get!UniqueConstraint is null);
+	assertTrue(cellOne.get!UniqueConstraint.cells.equal([cellTwo]));
+	assertTrue(cellTwo.get!UniqueConstraint.cells.equal([cellOne]));
+
+	cellOne.disconnect!UniqueConstraint(cellTwo,cellTwo,null,cellOne);
+
+	assertNull(cellOne.get!UniqueConstraint);
+	assertNull(cellTwo.get!UniqueConstraint);
 }
 
+@("core:sudoku:cell: get")
+unittest
+{
+	import core.constraint : UniqueConstraint;
 
+	Cell cellOne = new Cell(0);
+	Cell cellTwo = new Cell(0);
+	Cell cellTree = new Cell(0);
+
+	cellOne.addConstraint!UniqueConstraint(cellTwo,cellTree);
+
+	assertNotNull(cellOne.get!UniqueConstraint);
+	assertSame(cellOne.get!UniqueConstraint, cellOne.get(ConstraintType.Unique));
+}
+
+@("core:sudoku:cell: isValid")
+unittest
+{
+	import core.constraint : UniqueConstraint;
+
+	Cell cellOne = new Cell(0);
+
+	// cell doesn't have restrictions
+	assertTrue(cellOne.isValid(4));
+
+	cellOne.addConstraint!UniqueConstraint(new Cell(4));
+
+	// now cellOne is connected to a Cell under the UniqueConstraint
+	assertFalse(cellOne.isValid(4));
+}
+
+@("core:sudoku:cell: removeConstraint")
+unittest
+{
+	import std.algorithm : each;
+	import core.constraint : UniqueConstraint;
+
+	Cell cellOne = new Cell(0);
+	Cell cellTwo = new Cell(0);
+	Cell cellThree = new Cell(0);
+
+	cellOne.addConstraint!UniqueConstraint(cellTwo,cellThree);
+	cellOne.removeConstraint!UniqueConstraint;
+
+	[cellOne,cellTwo,cellThree].each!(cell => assertNull(cell.get!UniqueConstraint));
+}

--- a/source/core/sudoku/cell.d
+++ b/source/core/sudoku/cell.d
@@ -1,6 +1,7 @@
 module core.sudoku.cell;
 
 import core.constraint;
+import core.rule;
 
 public class Cell
 {
@@ -202,6 +203,7 @@ public class Cell
 	public int digit;
 
 	public Constraint[ConstraintType] constraints;
+	public Rule[RuleType] rules;
 }
 
 

--- a/source/core/sudoku/grid.d
+++ b/source/core/sudoku/grid.d
@@ -1,9 +1,6 @@
 module core.sudoku.grid;
 
-import std.algorithm : map;
-import std.array : array, join;
-import std.range : iota, front, transversal;
-import std.typecons : tuple, Tuple;
+import std.typecons : Tuple;
 
 import core.sudoku.box;
 import core.sudoku.cell;
@@ -50,8 +47,14 @@ public class Grid
 	 * Returns: `tuple`***("rows","columns","boxRows","boxColumns")*** with the
 	 *     dimensions of SudokuType
 	 */
-	public static auto dimensions(in SudokuType type)
+	public static Tuple!(int,"rows",
+							int,"columns",
+							int,"boxRows",
+							int,"boxColumns")
+	dimensions(in SudokuType type)
 	{
+		import std.typecons : tuple;
+
 		final switch (type)
 		{
 			case SudokuType.Sudoku4x4:
@@ -70,8 +73,13 @@ public class Grid
 	 *
 	 * Returns: `tuple`***("rows","columns","boxRows","boxColumns")***
 	 */
-	public auto dimensions() const
+	public Tuple!(const int,"rows",
+					const int,"columns",
+					const int,"boxRows",
+					const int,"boxColumns")
+	dimensions() const
 	{
+		import std.typecons : tuple;
 		return tuple!("rows","columns","boxRows","boxColumns")(rows,columns,boxRows,boxColumns);
 	}
 
@@ -98,6 +106,9 @@ public class Grid
 	 */
 	public void initialize(in int[][] digits)
 	{
+		import std.algorithm : map;
+		import std.array : array;
+
 		for (int row; row < columns; row++)
 		{
 			for (int col; col < rows; col++)
@@ -145,6 +156,9 @@ public class Grid
 	 */
 	public static int[][] toDigit(Cell[][] cells)
 	{
+		import std.algorithm : map;
+		import std.array : array;
+
 		return cells.map!(row => row.map!(cell => cell.digit).array).array;
 	}
 
@@ -159,6 +173,9 @@ public class Grid
 	 */
 	public static int[] toDigit(Cell[] cells)
 	{
+		import std.algorithm : map;
+		import std.array : array;
+
 		return cells.map!(cell => cell.digit).array;
 	}
 
@@ -197,6 +214,9 @@ public class Grid
 	}
 	body
 	{
+		import std.array : array;
+		import std.range : transversal;
+
 		return transversal(cells, index).array;
 	}
 
@@ -216,6 +236,8 @@ public class Grid
 	}
 	body
 	{
+		import std.range : join;
+
 		return boxes.join[index];
 	}
 
@@ -300,6 +322,8 @@ public class Grid
 
 	public static Cell[] toArray(Cell[][] cells)
 	{
+		import std.range : join;
+
 		return cells.join;
 	}
 
@@ -311,6 +335,9 @@ public class Grid
 	 */
 	public Cell[][] transposed()
 	{
+		import std.array : array;
+		import std.range : transversal;
+
 		Cell[][] ret;
 		foreach (i; 0..rows)
 		{
@@ -460,6 +487,7 @@ unittest
 unittest
 {
 	import std.algorithm : equal;
+	import std.range : join;
 
 	Grid grid = new Grid(SudokuType.Sudoku4x4);
 	grid.initialize(digits4x4);

--- a/source/core/sudoku/grid.d
+++ b/source/core/sudoku/grid.d
@@ -332,7 +332,6 @@ public class Grid
 
 
 version(unittest) { import aurorafw.unit; }
-
 version(unittest)
 {
 	import std.algorithm : each, equal, reverse;
@@ -367,12 +366,14 @@ version(unittest)
 @("core:sudoku:grid: box")
 unittest
 {
+	import std.algorithm : equal;
+
 	Grid grid = new Grid(SudokuType.Sudoku9x9);
 	grid.initialize(digits9x9);
 
 	Box b = grid.box(4);
 
-	assertTrue(b == grid.boxes[1][1]);
+	assertSame(b, grid.boxes[1][1]);
 	assertTrue(grid.toDigit(b.cells).equal([[0,0,8],
 											[3,0,7],
 											[0,0,0]]));
@@ -385,28 +386,34 @@ unittest
 	Grid grid = new Grid(SudokuType.Sudoku4x4);
 	grid.initialize(digits4x4);
 
-	assertTrue(grid[0,0] == grid.cells[0][0]);
-	assertTrue(grid.cell(0,0) == grid.cells[0][0]);
+	assertSame(grid[0,0], grid.cells[0][0]);
+	assertSame(grid.cell(0,0), grid.cells[0][0]);
 }
 
 @("core:sudoku:grid: columns")
 unittest
 {
+	import std.algorithm : each, equal;
+	import std.range : transposed;
+
 	Grid grid = new Grid(SudokuType.Sudoku6x6);
 	grid.initialize(digits6x6);
 
-	assertTrue(grid.transposed().each!((i, ref row) => row.equal(grid.column(cast(int) i))));
+	grid.transposed().each!((i, ref row) => assertTrue(row.equal(grid.column(cast(int) i))));
 	assertTrue(grid.toDigit(grid.column(0)).equal([2,3,0,4,0,0]));
 }
 
 @("core:sudoku:grid: diagonals")
 unittest
 {
+	import std.algorithm : equal;
+
 	Grid grid = new Grid(SudokuType.Sudoku4x4);
 	grid.initialize(digits4x4);
 
 	Cell[] main = [grid[0,0],grid[1,1],grid[2,2],grid[3,3]];
 	Cell[] anti = [grid[0,3],grid[1,2],grid[2,1],grid[3,0]];
+
 	assertTrue(grid.mainDiagonal().equal(main));
 	assertTrue(grid.antiDiagonal().equal(anti));
 	assertTrue(grid.toDigit(grid.mainDiagonal()).equal([1,2,0,1]));
@@ -420,38 +427,45 @@ unittest
 
 	auto dim = grid.dimensions();
 	auto dim_ = Grid.dimensions(SudokuType.Sudoku4x4);
-	assertTrue(dim == dim_);
+
+	assertEquals(dim, dim_);
 }
 
 @("core:sudoku:grid: initialize")
 unittest
 {
 	Grid grid = new Grid(SudokuType.Sudoku4x4);
-	assertTrue(grid.cells[0][0] is null);
+
+	assertNull(grid.cells[0][0]);
 
 	grid.initialize(digits4x4);
 
-	assertFalse(grid.cells[0][0] is null);
-	assertTrue(grid.cells[0][0].digit == 1);
+	assertNotNull(grid.cells[0][0]);
+	assertEquals(grid.cells[0][0].digit, 1);
 }
 
 @("core:sudoku:grid: rows")
 unittest
 {
+	import std.algorithm : each, equal;
+
 	Grid grid = new Grid(SudokuType.Sudoku6x6);
 	grid.initialize(digits6x6);
 
-	assertTrue(grid.cells.each!((i, ref row) => row.equal(grid.row(cast(int) i))));
+	grid.cells.each!((i, ref row) => assertTrue(row.equal(grid.row(cast(int) i))));
 	assertTrue(grid.toDigit(grid.row(0)).equal([2,0,0,0,0,0]));
 }
 
 @("core:sudoku:grid: toArray")
 unittest
 {
+	import std.algorithm : equal;
+
 	Grid grid = new Grid(SudokuType.Sudoku4x4);
 	grid.initialize(digits4x4);
 
 	Cell[] cells = join(grid.cells[0 .. $]);
+
 	assertTrue(grid.toArray().equal(cells));
 	assertTrue(Grid.toDigit(grid.toArray()).equal([1,0,0,3,0,2,1,4,4,0,0,2,0,3,4,1]));
 }
@@ -459,6 +473,8 @@ unittest
 @("core:sudoku:grid: toDigit")
 unittest
 {
+	import std.algorithm : equal;
+
 	Grid grid = new Grid(SudokuType.Sudoku9x9);
 	grid.initialize(digits9x9);
 
@@ -469,6 +485,8 @@ unittest
 @("core:sudoku:grid: transposed")
 unittest
 {
+	import std.algorithm : equal;
+
 	Grid grid = new Grid(SudokuType.Sudoku4x4);
 	grid.initialize(digits4x4);
 

--- a/source/core/sudoku/sudoku.d
+++ b/source/core/sudoku/sudoku.d
@@ -139,7 +139,7 @@ version(unittest) { import aurorafw.unit; }
 
 version(unittest)
 {
-	import core.rule.rule : addRuleClassic;
+	import core.rule.classic;
 
 	int[][] classic4x4 =   [[1, 0, 0, 3],
 							[0, 2, 1, 4],
@@ -165,15 +165,15 @@ version(unittest)
 								[3, 1, 2, 6, 4, 5],
 								[6, 4, 5, 1, 3, 2]];
 
-	int[][] classic9x9 =  [[0, 0, 3, 2, 6, 0, 0, 0, 0],
-								[0, 0, 7, 0, 0, 1, 0, 2, 3],
-								[0, 8, 6, 0, 0, 0, 4, 0, 0],
-								[5, 0, 0, 0, 0, 8, 0, 9, 0],
-								[6, 4, 0, 3, 0, 7, 0, 1, 0],
-								[0, 0, 0, 0, 0, 0, 0, 0, 5],
-								[9, 2, 0, 0, 4, 0, 0, 0, 7],
-								[0, 0, 0, 0, 0, 5, 9, 8, 0],
-								[0, 0, 1, 6, 0, 0, 0, 3, 0]];
+	int[][] classic9x9 =   [[0, 0, 3, 2, 6, 0, 0, 0, 0],
+							[0, 0, 7, 0, 0, 1, 0, 2, 3],
+							[0, 8, 6, 0, 0, 0, 4, 0, 0],
+							[5, 0, 0, 0, 0, 8, 0, 9, 0],
+							[6, 4, 0, 3, 0, 7, 0, 1, 0],
+							[0, 0, 0, 0, 0, 0, 0, 0, 5],
+							[9, 2, 0, 0, 4, 0, 0, 0, 7],
+							[0, 0, 0, 0, 0, 5, 9, 8, 0],
+							[0, 0, 1, 6, 0, 0, 0, 3, 0]];
 
 	int[][] classicSolve9x9 =  [[1, 5, 3, 2, 6, 4, 8, 7, 9],
 								[4, 9, 7, 5, 8, 1, 6, 2, 3],
@@ -191,7 +191,7 @@ unittest
 {
 	Grid grid = new Grid(SudokuType.Sudoku4x4);
 	grid.initialize(classic4x4);
-	addRuleClassic(grid);
+	ClassicRule.create(grid);
 
 	Sudoku sudoku = new Sudoku(grid);
 
@@ -203,7 +203,7 @@ unittest
 {
 	Grid grid = new Grid(SudokuType.Sudoku6x6);
 	grid.initialize(classic6x6);
-	addRuleClassic(grid);
+	ClassicRule.create(grid);
 
 	Sudoku sudoku = new Sudoku(grid);
 
@@ -215,7 +215,7 @@ unittest
 {
 	Grid grid = new Grid(SudokuType.Sudoku9x9);
 	grid.initialize(classic9x9);
-	addRuleClassic(grid);
+	ClassicRule.create(grid);
 
 	Sudoku sudoku = new Sudoku(grid);
 
@@ -225,7 +225,7 @@ unittest
 
 version(unittest)
 {
-	import core.rule.rule : addRuleX;
+	import core.rule.x;
 
 	int[][] x4x4 = [[1,2,0,0],
 					[0,0,0,0],
@@ -257,11 +257,10 @@ unittest
 {
 	Grid grid = new Grid(SudokuType.Sudoku4x4);
 	grid.initialize(x4x4);
-	addRuleClassic(grid);
+	ClassicRule.create(grid);
+	XRule.create(grid);
 
 	Sudoku sudoku = new Sudoku(grid);
-
-	addRuleX(sudoku.grid);
 
 	assertTrue(sudoku.solve() == xSolve4x4);
 }
@@ -271,8 +270,8 @@ unittest
 {
 	Grid grid = new Grid(SudokuType.Sudoku6x6);
 	grid.initialize(x6x6);
-	addRuleClassic(grid);
-	addRuleX(grid);
+	ClassicRule.create(grid);
+	XRule.create(grid);
 
 	Sudoku sudoku = new Sudoku(grid);
 

--- a/source/core/sudoku/sudoku.d
+++ b/source/core/sudoku/sudoku.d
@@ -136,7 +136,6 @@ public class Sudoku
 
 
 version(unittest) { import aurorafw.unit; }
-
 version(unittest)
 {
 	import core.rule.classic;
@@ -189,37 +188,43 @@ version(unittest)
 @("core:sudoku:sudoku: classic solve 4x4")
 unittest
 {
+	import std.algorithm : equal;
+
 	Grid grid = new Grid(SudokuType.Sudoku4x4);
 	grid.initialize(classic4x4);
 	ClassicRule.create(grid);
 
 	Sudoku sudoku = new Sudoku(grid);
 
-	assertTrue(sudoku.solve() == classicSolve4x4);
+	assertTrue(sudoku.solve().equal(classicSolve4x4));
 }
 
 @("core:sudoku:sudoku: classic solve 6x6")
 unittest
 {
+	import std.algorithm : equal;
+
 	Grid grid = new Grid(SudokuType.Sudoku6x6);
 	grid.initialize(classic6x6);
 	ClassicRule.create(grid);
 
 	Sudoku sudoku = new Sudoku(grid);
 
-	assertTrue(sudoku.solve() == classicSolve6x6);
+	assertTrue(sudoku.solve().equal(classicSolve6x6));
 }
 
 @("core:sudoku:sudoku: classic solve 9x9")
 unittest
 {
+	import std.algorithm : equal;
+
 	Grid grid = new Grid(SudokuType.Sudoku9x9);
 	grid.initialize(classic9x9);
 	ClassicRule.create(grid);
 
 	Sudoku sudoku = new Sudoku(grid);
 
-	assertTrue(sudoku.solve() == classicSolve9x9);
+	assertTrue(sudoku.solve().equal(classicSolve9x9));
 }
 
 
@@ -255,6 +260,8 @@ version(unittest)
 @("core:sudoku:sudoku: x solve 4x4")
 unittest
 {
+	import std.algorithm : equal;
+
 	Grid grid = new Grid(SudokuType.Sudoku4x4);
 	grid.initialize(x4x4);
 	ClassicRule.create(grid);
@@ -262,12 +269,14 @@ unittest
 
 	Sudoku sudoku = new Sudoku(grid);
 
-	assertTrue(sudoku.solve() == xSolve4x4);
+	assertTrue(sudoku.solve().equal(xSolve4x4));
 }
 
 @("core:sudoku:sudoku: x solve 6x6")
 unittest
 {
+	import std.algorithm : equal;
+
 	Grid grid = new Grid(SudokuType.Sudoku6x6);
 	grid.initialize(x6x6);
 	ClassicRule.create(grid);
@@ -275,5 +284,5 @@ unittest
 
 	Sudoku sudoku = new Sudoku(grid);
 
-	assertTrue(sudoku.solve() == xSolve6x6);
+	assertTrue(sudoku.solve().equal(xSolve6x6));
 }

--- a/source/core/sudoku/sudoku.d
+++ b/source/core/sudoku/sudoku.d
@@ -1,8 +1,6 @@
 module core.sudoku.sudoku;
 
-import std.experimental.logger;
 import std.json;
-import std.typecons : tuple;
 
 import core.rule.rule;
 import core.sudoku.cell;


### PR DESCRIPTION
```md
What changed:
unittests:
 - fixed wrong tests when using `each`
 - imports are relative to the unittest it self

imports:
 - removed not needed global imports
 - imports are relative to the function
```